### PR TITLE
feat: scaffold landing page sections

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,19 +1,23 @@
 "use client";
 import React from "react";
-import Menu from "../components/Menu";
-import Link from "next/link";
+import { Header } from "../components/Header";
+import HeroSection from "../components/HeroSection";
+import ProvenanceSection from "../components/ProvenanceSection";
+import TopTournamentsSection from "../components/TopTournamentsSection";
+import MarketplaceSection from "../components/MarketplaceSection";
+import StayTunedSection from "../components/StayTunedSection";
+import { Footer } from "../components/Footer";
 
 export default function HomePage() {
   return (
-    <main className="flex flex-col items-center">
-      <Menu />
-      <h1 className="text-3xl font-bold mt-6">PokerBoots × Starknet</h1>
-      <Link
-        href="/play"
-        className="mt-4 px-6 py-2 bg-blue-700 rounded hover:bg-blue-900"
-      >
-        Play Tournament
-      </Link>
+    <main className="flex flex-col items-stretch">
+      <Header />
+      <HeroSection />
+      <ProvenanceSection />
+      <TopTournamentsSection />
+      <MarketplaceSection />
+      <StayTunedSection />
+      <Footer />
     </main>
   );
 }

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -21,10 +21,11 @@ type HeaderMenuLink = {
 };
 
 export const menuLinks: HeaderMenuLink[] = [
-  {
-    label: "Home",
-    href: "/",
-  }
+  { label: "Home", href: "/#home" },
+  { label: "How it Works", href: "/#how" },
+  { label: "Top Tournaments", href: "/#tournaments" },
+  { label: "Marketplace", href: "/#marketplace" },
+  { label: "Play", href: "/play" },
 ];
 
 export const HeaderMenuLinks = () => {
@@ -135,6 +136,7 @@ export const Header = () => {
                 setIsDrawerOpen(false);
               }}
             >
+              <HeaderMenuLinks />
             </ul>
           )}
         </div>
@@ -153,6 +155,7 @@ export const Header = () => {
           </div>
         </Link>
         <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">
+          <HeaderMenuLinks />
         </ul>
       </div>
       <div className="navbar-end flex-grow mr-2 gap-4">

--- a/packages/nextjs/components/MarketplaceSection.tsx
+++ b/packages/nextjs/components/MarketplaceSection.tsx
@@ -1,0 +1,73 @@
+/**
+ * MarketplaceSection – simplified marketplace view.
+ */
+export default function MarketplaceSection() {
+  const entries = Array.from({ length: 6 }).map((_, i) => ({
+    id: i,
+    name: `NFT Tournament ${i + 1}`,
+    creator: `Creator ${i + 1}`,
+    buyIn: 5 + i * 5,
+    date: "Jun 10",
+    sold: `${20 + i * 3}/${100 + i * 10}`,
+    prize: 1000 + i * 500,
+  }));
+
+  return (
+    <section
+      id="marketplace"
+      className="py-24 px-6 md:px-12 bg-[#0a1a38] text-white"
+    >
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-8">
+          NFT Marketplace
+        </h2>
+
+        {/* filters */}
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+          <div className="flex gap-2">
+            {["Upcoming", "Active", "Finished"].map((f) => (
+              <button
+                key={f}
+                className="px-3 py-1 bg-white/5 rounded-full border border-white/10 text-sm"
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+          <input
+            type="text"
+            placeholder="Search"
+            className="px-3 py-2 rounded-md text-[#0c1a3a]"
+          />
+          <div className="font-semibold">🏆 Total Prize Money: $213,400</div>
+        </div>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+          {entries.map((e) => (
+            <div
+              key={e.id}
+              className="bg-white/5 p-4 rounded-xl border border-white/10 flex flex-col"
+            >
+              <img
+                src={`https://placehold.co/600x400.png?text=NFT+${e.id + 1}`}
+                alt="NFT"
+                className="w-full h-40 object-cover rounded"
+              />
+              <h3 className="mt-4 font-semibold">{e.name}</h3>
+              <p className="text-sm text-slate-300">{e.creator}</p>
+              <div className="mt-2 text-sm space-y-1">
+                <p>Buy-in Price: ${e.buyIn}</p>
+                <p>Tournament Date: {e.date}</p>
+                <p>Amount Sold / Refunded: {e.sold}</p>
+                <p>Finisher Prize: ${e.prize.toLocaleString()}</p>
+              </div>
+              <button className="mt-4 px-4 py-2 bg-yellow-400 text-[#0c1a3a] font-semibold rounded hover:bg-yellow-300">
+                See Prize Breakdown
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/nextjs/components/ProvenanceSection.tsx
+++ b/packages/nextjs/components/ProvenanceSection.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+
+/**
+ * ProvenanceSection – two-column explainer with payout calculator.
+ */
+export default function ProvenanceSection() {
+  const [buyIn, setBuyIn] = useState(10);
+  const [players, setPlayers] = useState(100);
+
+  const prizePool = buyIn * players;
+  const payout = {
+    winner: prizePool * 0.4,
+    top: prizePool * 0.4,
+    creator: prizePool * 0.1,
+    platform: prizePool * 0.1,
+  };
+
+  return (
+    <section id="how" className="py-24 px-6 md:px-12 bg-[#0a1a38] text-white">
+      <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center">
+        {/* left illustration */}
+        <div className="flex justify-center">
+          <div className="w-64 h-64 bg-white/10 rounded-xl" />
+        </div>
+
+        {/* right content */}
+        <div>
+          <ol className="space-y-4 text-lg list-decimal list-inside">
+            <li>Buy NFT Ticket</li>
+            <li>Join Tournament</li>
+            <li>Win in Top 10%</li>
+            <li>Get Paid</li>
+          </ol>
+
+          {/* calculator */}
+          <div className="mt-8 p-6 bg-white/5 rounded-xl border border-white/10">
+            <div className="flex flex-col md:flex-row gap-4">
+              <label className="flex-1 text-sm">
+                <span className="block mb-1 text-yellow-300">Buy-in ($)</span>
+                <select
+                  value={buyIn}
+                  onChange={(e) => setBuyIn(Number(e.target.value))}
+                  className="w-full px-3 py-2 rounded-md text-[#0c1a3a]"
+                >
+                  {[10, 20, 50, 100].map((v) => (
+                    <option key={v} value={v}>
+                      ${v}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex-1 text-sm">
+                <span className="block mb-1 text-yellow-300">Players</span>
+                <input
+                  type="range"
+                  min={10}
+                  max={500}
+                  value={players}
+                  onChange={(e) => setPlayers(Number(e.target.value))}
+                  className="w-full"
+                />
+                <div className="text-sm text-right mt-1">{players}</div>
+              </label>
+            </div>
+
+            <ul className="mt-4 text-sm space-y-1">
+              <li>Total Prize Pool: ${prizePool.toLocaleString()}</li>
+              <li>Winner (40%): ${payout.winner.toLocaleString()}</li>
+              <li>Top 10% (40%): ${payout.top.toLocaleString()}</li>
+              <li>Creator (10%): ${payout.creator.toLocaleString()}</li>
+              <li>Platform (10%): ${payout.platform.toLocaleString()}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/nextjs/components/StayTunedSection.tsx
+++ b/packages/nextjs/components/StayTunedSection.tsx
@@ -1,4 +1,4 @@
-import { FaTwitter, FaInstagram, FaDiscord } from 'react-icons/fa';
+import { FaTwitter, FaInstagram, FaDiscord } from "react-icons/fa";
 
 /**
  * StayTunedSection – social‑follow banner with neon glow + diagonal separator.
@@ -6,21 +6,31 @@ import { FaTwitter, FaInstagram, FaDiscord } from 'react-icons/fa';
  */
 export default function StayTunedSection() {
   return (
-    <section id="stay" className="relative bg-[#0e244f] py-24 px-6 md:px-12 text-center overflow-hidden">
+    <section
+      id="community"
+      className="relative bg-[#0e244f] py-24 px-6 md:px-12 text-center overflow-hidden"
+    >
       {/* diagonal top separator */}
       <div className="absolute -top-16 left-0 w-full h-16 bg-gradient-to-br from-transparent via-blue-900/60 to-blue-950/80 skew-y-[-3deg] origin-top" />
 
       {/* subtle radial glow */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-800/10 via-indigo-600/10 to-purple-700/10 rounded-[40%] blur-[180px] -z-10" />
 
-      <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-yellow-300">Stay Tuned</h2>
+      <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-yellow-300">
+        Highlights & Community
+      </h2>
       <p className="max-w-xl mx-auto mt-4 text-slate-300">
-        Follow us for launch announcements, tournament drops, and behind‑the‑scenes updates.
+        Highlight reels, testimonials and more. Join our community to keep the
+        action going.
       </p>
 
       {/* social icons */}
       <div className="mt-10 flex justify-center gap-8 text-4xl">
-        <SocialIcon href="https://twitter.com/pokerboots" label="Twitter" className="hover:text-sky-400">
+        <SocialIcon
+          href="https://twitter.com/pokerboots"
+          label="Twitter"
+          className="hover:text-sky-400"
+        >
           <FaTwitter />
         </SocialIcon>
         <SocialIcon href="#" label="Instagram" className="hover:text-pink-400">
@@ -30,6 +40,12 @@ export default function StayTunedSection() {
           <FaDiscord />
         </SocialIcon>
       </div>
+      <p className="mt-8 text-slate-300">
+        <a href="#" className="underline text-yellow-300">
+          Join our Discord
+        </a>{" "}
+        to share your best hands.
+      </p>
     </section>
   );
 }
@@ -41,7 +57,7 @@ interface IconProps {
   children: React.ReactNode;
   className?: string;
 }
-const SocialIcon = ({ href, label, children, className = '' }: IconProps) => (
+const SocialIcon = ({ href, label, children, className = "" }: IconProps) => (
   <a
     href={href}
     target="_blank"

--- a/packages/nextjs/components/TopTournamentsSection.tsx
+++ b/packages/nextjs/components/TopTournamentsSection.tsx
@@ -1,0 +1,48 @@
+/**
+ * TopTournamentsSection – grid of tournament cards.
+ */
+export default function TopTournamentsSection() {
+  const tournaments = Array.from({ length: 6 }).map((_, i) => ({
+    id: i,
+    name: `Tournament ${i + 1}`,
+    buyIn: 10 + i * 5,
+    prizePool: 5000 + i * 1000,
+    players: 100 + i * 20,
+    starts: "2h 15m",
+  }));
+
+  return (
+    <section
+      id="tournaments"
+      className="py-24 px-6 md:px-12 bg-[#081224] text-white"
+    >
+      <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-12">
+        Top Tournaments
+      </h2>
+      <div className="max-w-6xl mx-auto grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        {tournaments.map((t) => (
+          <div
+            key={t.id}
+            className="bg-white/5 p-4 rounded-xl border border-white/10 flex flex-col"
+          >
+            <img
+              src={`https://placehold.co/600x400.png?text=NFT+${t.id + 1}`}
+              alt="NFT"
+              className="w-full h-40 object-cover rounded"
+            />
+            <h3 className="mt-4 font-semibold">{t.name}</h3>
+            <div className="mt-2 text-sm space-y-1">
+              <p>Buy-in: ${t.buyIn}</p>
+              <p>Total Prize Pool: ${t.prizePool.toLocaleString()}</p>
+              <p>Players Joined: {t.players}</p>
+              <p>Starts in {t.starts}</p>
+            </div>
+            <button className="mt-4 px-4 py-2 bg-yellow-400 text-[#0c1a3a] font-semibold rounded hover:bg-yellow-300">
+              View Tournament
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- build landing page skeleton with hero, provenance calculator, tournaments, marketplace and community sections
- expand header navigation with new section links
- refresh social section with Discord invitation

## Testing
- `yarn next:lint`
- `yarn test:nextjs`


------
https://chatgpt.com/codex/tasks/task_e_6891a93b20ac8324ad159a0f229b33f2