### PR TITLE
fix: remove Vercel output directory

### DIFF
--- a/packages/nextjs/vercel.json
+++ b/packages/nextjs/vercel.json
@@ -1,5 +1,4 @@
 {
   "installCommand": "yarn install",
-  "buildCommand": "yarn build",
-  "outputDirectory": ".next"
+  "buildCommand": "yarn build"
 }


### PR DESCRIPTION
## Summary
- remove explicit output directory from Vercel config so Next.js routes deploy correctly

## Testing
- `yarn workspace @ss-2/nextjs lint`

------
https://chatgpt.com/codex/tasks/task_e_6891b34d10e88324aa85b2052dce3eea