### PR TITLE
Implement responsive layout and payout calculator

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -112,7 +112,7 @@ export const Header = () => {
   ]);
 
   return (
-    <div className=" lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2">
+    <div className=" lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2 flex-wrap gap-2">
       <div className="navbar-start w-auto lg:w-1/2 -mr-2">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <label

--- a/packages/nextjs/components/NFTSaleSection.tsx
+++ b/packages/nextjs/components/NFTSaleSection.tsx
@@ -221,9 +221,9 @@ const ColorField = ({
 /* -------------------- SVG Preview -------------------- */
 const SvgPreview = (p: Record<string, string>) => (
   <svg
-    width="520"
-    height="720"
-    viewBox="0 0 520 720"
+    width="360"
+    height="640"
+    viewBox="0 0 360 640"
     className="shadow-2xl rounded-2xl"
     style={{ background: p.bgColor, border: `10px solid ${p.borderColor}` }}
   >
@@ -267,36 +267,36 @@ const SvgPreview = (p: Record<string, string>) => (
       </defs>
     )}
     {p.bgStyle === "dots" && (
-      <rect width="520" height="720" fill="url(#dots)" />
+      <rect width="360" height="640" fill="url(#dots)" />
     )}
     {p.bgStyle === "crosses" && (
-      <rect width="520" height="720" fill="url(#cross)" />
+      <rect width="360" height="640" fill="url(#cross)" />
     )}
     {p.bgStyle === "hearts" && (
-      <rect width="520" height="720" fill="url(#hearts)" />
+      <rect width="360" height="640" fill="url(#hearts)" />
     )}
 
     {/* artwork 50 % height + rounded, fat inner border */}
 
     <image
       href={nftPlaceholder.src}
-      x="40"
-      y="70"
-      width="440"
-      height="300"
+      x="30"
+      y="80"
+      width="300"
+      height="360"
       preserveAspectRatio="xMidYMid slice"
     />
     <rect
-      x="40"
-      y="70"
-      width="440"
-      height="300"
+      x="30"
+      y="80"
+      width="300"
+      height="360"
       fill="none"
       stroke={p.imgBorderColor}
       strokeWidth="8"
     />
     {/* title (max two rows) */}
-    <foreignObject x="40" y="0" width="440" height="64">
+    <foreignObject x="30" y="0" width="300" height="64">
       <div
         {...{ xmlns: "http://www.w3.org/1999/xhtml" }}
         style={{
@@ -316,7 +316,7 @@ const SvgPreview = (p: Record<string, string>) => (
     {/* price & creator */}
     <text
       x="50%"
-      y="400"
+      y="470"
       fill={p.textColor}
       color={p.textColor}
       fontFamily="sans-serif"
@@ -327,8 +327,8 @@ const SvgPreview = (p: Record<string, string>) => (
       ${p.price}
     </text>
     <text
-      x="40"
-      y="420"
+      x="30"
+      y="490"
       fill={p.textColor}
       fontFamily="sans-serif"
       fontSize="18"
@@ -347,7 +347,7 @@ const SvgPreview = (p: Record<string, string>) => (
       -- DESCRIPTION --
     </text>
     {/* description block (same transparent bg as details) */}
-    <foreignObject x="60" y="450" width="416" height="100">
+    <foreignObject x="40" y="520" width="280" height="80">
       <text
         {...{ xmlns: "http://www.w3.org/1999/xhtml" }}
         style={{
@@ -364,17 +364,17 @@ const SvgPreview = (p: Record<string, string>) => (
 
     {/* details header + bg */}
     <rect
-      x="40"
-      y="425"
-      width="440"
-      height="264"
+      x="30"
+      y="510"
+      width="300"
+      height="120"
       rx="12"
       fill="#FFFFFF"
       opacity="0.1"
     />
     <text
       x="30%"
-      y="570"
+      y="610"
       fill={p.textColor}
       fontFamily="sans-serif"
       fontSize="18"
@@ -387,11 +387,11 @@ const SvgPreview = (p: Record<string, string>) => (
     {["Game", "Entries", "Supply", "Refund", "Date"].map((lbl, i) => (
       <text
         key={lbl}
-        x="60"
-        y={590 + i * 22}
+        x="40"
+        y={630 + i * 20}
         fill={p.textColor}
         fontFamily="sans-serif"
-        fontSize="18"
+        fontSize="14"
       >
         {lbl}:
       </text>
@@ -400,30 +400,14 @@ const SvgPreview = (p: Record<string, string>) => (
     {[p.game, p.type, p.supply, p.refund, p.date].map((lbl, i) => (
       <text
         key={lbl}
-        x="160"
-        y={590 + i * 22}
+        x="140"
+        y={630 + i * 20}
         fill={p.textColor}
         fontFamily="sans-serif"
-        fontSize="18"
+        fontSize="14"
       >
         {lbl}
       </text>
     ))}
-
-    {/* values column */}
-
-    <foreignObject x="200" y="746" width="280" height="60">
-      <div
-        {...{ xmlns: "http://www.w3.org/1999/xhtml" }}
-        style={{
-          color: "#9CA3AF",
-          fontFamily: "sans-serif",
-          fontSize: 16,
-          whiteSpace: "pre-wrap",
-        }}
-      >
-        {p.date}
-      </div>
-    </foreignObject>
   </svg>
 );

--- a/packages/nextjs/components/ProvenanceSection.tsx
+++ b/packages/nextjs/components/ProvenanceSection.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import {
+  ArrowLongRightIcon,
+  ArrowLongDownIcon,
+} from "@heroicons/react/24/outline";
 
 /**
  * ProvenanceSection – two-column explainer with payout calculator.
@@ -6,17 +10,57 @@ import { useState } from "react";
 export default function ProvenanceSection() {
   const [buyIn, setBuyIn] = useState(10);
   const [players, setPlayers] = useState(100);
+  const [showTable, setShowTable] = useState(false);
 
   const prizePool = buyIn * players;
   const payout = {
-    winner: prizePool * 0.4,
+    winner: prizePool * 0.3,
+    finalTable: prizePool * 0.1,
     top: prizePool * 0.4,
     creator: prizePool * 0.1,
     platform: prizePool * 0.1,
   };
 
+  const buildDistribution = () => {
+    const rows: { position: number; pct: number; prize: number }[] = [];
+    // winner
+    rows.push({ position: 1, pct: 0.3, prize: payout.winner });
+
+    const finalTableSize = Math.min(9, players);
+    const ftSpots = finalTableSize - 1; // excluding winner
+    const ftWeightSum = (ftSpots * (ftSpots + 1)) / 2;
+    for (let i = 2; i <= finalTableSize; i++) {
+      const weight = finalTableSize - i + 1;
+      const pct = (weight / ftWeightSum) * 0.1;
+      rows.push({ position: i, pct, prize: pct * prizePool });
+    }
+
+    const topCount = Math.ceil(players * 0.15);
+    const remSpots = Math.max(topCount - finalTableSize, 0);
+    const topWeightSum = (remSpots * (remSpots + 1)) / 2;
+    for (let i = finalTableSize + 1; i <= topCount; i++) {
+      const weight = topCount - i + 1;
+      const pct = (weight / topWeightSum) * 0.4;
+      rows.push({ position: i, pct, prize: pct * prizePool });
+    }
+
+    return rows;
+  };
+
+  const distribution = buildDistribution();
+
+  const steps = [
+    "Buy NFT Ticket",
+    "Join Tournament",
+    "Finish in Top 15%",
+    "Get Paid",
+  ];
+
   return (
     <section id="how" className="py-24 px-6 md:px-12 bg-[#0a1a38] text-white">
+      <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-12">
+        How It Works
+      </h2>
       <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-12 items-center">
         {/* left illustration */}
         <div className="flex justify-center">
@@ -25,12 +69,21 @@ export default function ProvenanceSection() {
 
         {/* right content */}
         <div>
-          <ol className="space-y-4 text-lg list-decimal list-inside">
-            <li>Buy NFT Ticket</li>
-            <li>Join Tournament</li>
-            <li>Win in Top 10%</li>
-            <li>Get Paid</li>
-          </ol>
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            {steps.map((s, i) => (
+              <div key={s} className="flex items-center">
+                <div className="px-4 py-3 bg-white/5 rounded-lg border border-white/10 text-sm text-center">
+                  {s}
+                </div>
+                {i < steps.length - 1 && (
+                  <>
+                    <ArrowLongRightIcon className="hidden md:block w-6 h-6 mx-2 text-yellow-300" />
+                    <ArrowLongDownIcon className="md:hidden w-6 h-6 mx-2 text-yellow-300" />
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
 
           {/* calculator */}
           <div className="mt-8 p-6 bg-white/5 rounded-xl border border-white/10">
@@ -63,13 +116,54 @@ export default function ProvenanceSection() {
               </label>
             </div>
 
-            <ul className="mt-4 text-sm space-y-1">
-              <li>Total Prize Pool: ${prizePool.toLocaleString()}</li>
-              <li>Winner (40%): ${payout.winner.toLocaleString()}</li>
-              <li>Top 10% (40%): ${payout.top.toLocaleString()}</li>
-              <li>Creator (10%): ${payout.creator.toLocaleString()}</li>
-              <li>Platform (10%): ${payout.platform.toLocaleString()}</li>
-            </ul>
+            <div className="mt-4 grid sm:grid-cols-2 gap-4 text-sm">
+              <div className="p-3 bg-white/10 rounded">
+                Total Prize Pool: ${prizePool.toLocaleString()}
+              </div>
+              <div className="p-3 bg-white/10 rounded">
+                Winner (30%): ${payout.winner.toLocaleString()}
+              </div>
+              <div className="p-3 bg-white/10 rounded">
+                Final Table (10%): ${payout.finalTable.toLocaleString()}
+              </div>
+              <div className="p-3 bg-white/10 rounded">
+                Top 15% (40%): ${payout.top.toLocaleString()}
+              </div>
+              <div className="p-3 bg-white/10 rounded">
+                Creator (10%): ${payout.creator.toLocaleString()}
+              </div>
+              <div className="p-3 bg-white/10 rounded">
+                Platform (10%): ${payout.platform.toLocaleString()}
+              </div>
+            </div>
+
+            <button
+              className="mt-6 px-4 py-2 bg-yellow-400 text-[#0c1a3a] font-semibold rounded hover:bg-yellow-300"
+              onClick={() => setShowTable((v) => !v)}
+            >
+              {showTable ? "Hide" : "Show"} Prize Table
+            </button>
+
+            {showTable && (
+              <table className="mt-4 w-full text-sm">
+                <thead>
+                  <tr className="text-left">
+                    <th className="py-1">Position</th>
+                    <th className="py-1">% of Pool</th>
+                    <th className="py-1">Prize ($)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {distribution.map((d) => (
+                    <tr key={d.position} className="odd:bg-white/5">
+                      <td className="py-1 px-2">{d.position}</td>
+                      <td className="py-1 px-2">{(d.pct * 100).toFixed(2)}%</td>
+                      <td className="py-1 px-2">{d.prize.toFixed(2)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
         </div>
       </div>

--- a/packages/nextjs/pages/HomePage.tsx
+++ b/packages/nextjs/pages/HomePage.tsx
@@ -1,10 +1,10 @@
 // HomePage.tsx
 
-import HeroSection from '../components/HeroSection';
-import NftSaleSection from '../components/NFTSaleSection';
-import TournamentBoards from '../components/TournamentBoards';
-import  StayTunedSection from '../components/StayTunedSection';
-import Menu from '../components/Menu';
+import { Header } from "../components/Header";
+import HeroSection from "../components/HeroSection";
+import NftSaleSection from "../components/NFTSaleSection";
+import TournamentBoards from "../components/TournamentBoards";
+import StayTunedSection from "../components/StayTunedSection";
 
 /**
  * Home landing page – blue ✕ gold palette
@@ -13,7 +13,7 @@ import Menu from '../components/Menu';
 export default function HomePage() {
   return (
     <div className="min-h-screen text-white bg-gradient-to-b from-[#02040b] via-[#0c1a3a] to-[#102047] overflow-x-hidden">
-      <Menu />
+      <Header />
       <HeroSection />
       <NftSaleSection />
       <TournamentBoards />
@@ -21,6 +21,3 @@ export default function HomePage() {
     </div>
   );
 }
-
-
-


### PR DESCRIPTION
## Summary
- make header navigation responsive and avoid duplicate menus
- render NFT previews in tall 360x640 format
- overhaul "How It Works" with step timeline, new payout percentages, and prize breakdown table

## Testing
- `yarn next:lint`
- `yarn workspace @ss-2/nextjs vitest run` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6891bda58dd48324a2056080d816f32d