### PR TITLE
feat: add modular nft marketplace ui kit

### DIFF
--- a/packages/nextjs/app/nft/[id]/page.tsx
+++ b/packages/nextjs/app/nft/[id]/page.tsx
@@ -1,0 +1,11 @@
+import NFTDetail from "~~/components/ui/NFTDetail";
+
+const NFTPage = () => {
+  return (
+    <main className="p-6">
+      <NFTDetail />
+    </main>
+  );
+};
+
+export default NFTPage;

--- a/packages/nextjs/components/MarketplaceSection.tsx
+++ b/packages/nextjs/components/MarketplaceSection.tsx
@@ -1,71 +1,29 @@
-/**
- * MarketplaceSection – simplified marketplace view.
- */
+import NFTCard from "./ui/NFTCard";
+import NFTGrid from "./ui/NFTGrid";
+import FiltersSidebar from "./ui/FiltersSidebar";
+
+const items = Array.from({ length: 8 }).map((_, i) => ({
+  id: i,
+  title: `NFT Item ${i + 1}`,
+  image: "/nft.png",
+  creator: "/logo.svg",
+  price: `${(i + 1) * 0.1} ETH`,
+  chainIcon: "/explorer-icon.svg",
+}));
+
 export default function MarketplaceSection() {
-  const entries = Array.from({ length: 6 }).map((_, i) => ({
-    id: i,
-    name: `NFT Tournament ${i + 1}`,
-    creator: `Creator ${i + 1}`,
-    buyIn: 5 + i * 5,
-    date: "Jun 10",
-    sold: `${20 + i * 3}/${100 + i * 10}`,
-    prize: 1000 + i * 500,
-  }));
-
   return (
-    <section
-      id="marketplace"
-      className="py-24 px-6 md:px-12 bg-[#0a1a38] text-white"
-    >
-      <div className="max-w-6xl mx-auto">
-        <h2 className="text-3xl md:text-4xl font-extrabold text-yellow-300 text-center mb-8">
-          NFT Marketplace
-        </h2>
-
-        {/* filters */}
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
-          <div className="flex gap-2">
-            {["Upcoming", "Active", "Finished"].map((f) => (
-              <button
-                key={f}
-                className="px-3 py-1 bg-white/5 rounded-full border border-white/10 text-sm"
-              >
-                {f}
-              </button>
-            ))}
-          </div>
-          <input
-            type="text"
-            placeholder="Search"
-            className="px-3 py-2 rounded-md text-[#0c1a3a]"
-          />
-          <div className="font-semibold">🏆 Total Prize Money: $213,400</div>
+    <section className="py-12">
+      <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-6">
+        <div className="md:col-span-3">
+          <FiltersSidebar />
         </div>
-
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
-          {entries.map((e) => (
-            <div
-              key={e.id}
-              className="bg-white/5 p-4 rounded-xl border border-white/10 flex flex-col"
-            >
-              <img
-                src={`https://placehold.co/600x400.png?text=NFT+${e.id + 1}`}
-                alt="NFT"
-                className="w-full h-40 object-cover rounded"
-              />
-              <h3 className="mt-4 font-semibold">{e.name}</h3>
-              <p className="text-sm text-slate-300">{e.creator}</p>
-              <div className="mt-2 text-sm space-y-1">
-                <p>Buy-in Price: ${e.buyIn}</p>
-                <p>Tournament Date: {e.date}</p>
-                <p>Amount Sold / Refunded: {e.sold}</p>
-                <p>Finisher Prize: ${e.prize.toLocaleString()}</p>
-              </div>
-              <button className="mt-4 px-4 py-2 bg-yellow-400 text-[#0c1a3a] font-semibold rounded hover:bg-yellow-300">
-                See Prize Breakdown
-              </button>
-            </div>
-          ))}
+        <div className="md:col-span-9">
+          <NFTGrid>
+            {items.map((item) => (
+              <NFTCard key={item.id} {...item} />
+            ))}
+          </NFTGrid>
         </div>
       </div>
     </section>

--- a/packages/nextjs/components/ui/Avatar.tsx
+++ b/packages/nextjs/components/ui/Avatar.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import React from "react";
+
+type AvatarProps = {
+  src: string;
+  alt: string;
+  size?: number;
+  variant?: "circle" | "square";
+};
+
+export const Avatar: React.FC<AvatarProps> = ({
+  src,
+  alt,
+  size = 40,
+  variant = "circle",
+}) => (
+  <div
+    className={`overflow-hidden ${
+      variant === "circle" ? "rounded-full" : "rounded-md"
+    }`}
+    style={{ width: size, height: size }}
+  >
+    <Image
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      className="object-cover"
+    />
+  </div>
+);
+
+export default Avatar;

--- a/packages/nextjs/components/ui/Badge.tsx
+++ b/packages/nextjs/components/ui/Badge.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+type BadgeProps = {
+  label: string;
+  variant?: "verified" | "new" | "sale";
+};
+
+const styles: Record<string, string> = {
+  verified: "bg-accent text-white",
+  new: "bg-green-500 text-white",
+  sale: "bg-primary text-background",
+};
+
+export const Badge: React.FC<BadgeProps> = ({
+  label,
+  variant = "verified",
+}) => (
+  <span
+    className={`px-2 py-1 text-xs font-medium rounded-full ${styles[variant]}`}
+  >
+    {label}
+  </span>
+);
+
+export default Badge;

--- a/packages/nextjs/components/ui/Button.tsx
+++ b/packages/nextjs/components/ui/Button.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "ghost" | "pill";
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = "primary",
+  className = "",
+  children,
+  ...props
+}) => {
+  const base =
+    "px-4 py-2 font-semibold transition-transform duration-200 ease-out disabled:opacity-50 disabled:cursor-not-allowed";
+  const variants: Record<string, string> = {
+    primary: "bg-accent text-white rounded-md hover:scale-105 hover:shadow-lg",
+    secondary:
+      "bg-primary text-background rounded-md hover:scale-105 hover:shadow-lg",
+    ghost:
+      "bg-transparent text-accent border border-border rounded-md hover:bg-accent/10",
+    pill: "bg-accent text-white rounded-full hover:scale-105 hover:shadow-lg",
+  };
+
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/packages/nextjs/components/ui/Dropdown.tsx
+++ b/packages/nextjs/components/ui/Dropdown.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+type Option = { label: string; value: string };
+
+type DropdownProps = {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const Dropdown: React.FC<DropdownProps> = ({
+  options,
+  value,
+  onChange,
+}) => (
+  <select
+    className="w-full bg-transparent border border-border rounded-md px-3 py-2"
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+  >
+    {options.map((opt) => (
+      <option
+        key={opt.value}
+        value={opt.value}
+        className="bg-primary text-background"
+      >
+        {opt.label}
+      </option>
+    ))}
+  </select>
+);
+
+export default Dropdown;

--- a/packages/nextjs/components/ui/FiltersSidebar.tsx
+++ b/packages/nextjs/components/ui/FiltersSidebar.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import Dropdown from "./Dropdown";
+import Button from "./Button";
+
+const chains = ["Ethereum", "Polygon", "Solana"];
+const categories = ["Art", "Music", "Games", "Other"];
+const sorts = [
+  { label: "Recently Listed", value: "recent" },
+  { label: "Low to High", value: "asc" },
+  { label: "High to Low", value: "desc" },
+];
+
+export const FiltersSidebar: React.FC = () => {
+  const [selectedChains, setSelectedChains] = useState<string[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [sort, setSort] = useState("recent");
+
+  const toggle = (
+    value: string,
+    list: string[],
+    setter: (v: string[]) => void,
+  ) => {
+    setter(
+      list.includes(value) ? list.filter((c) => c !== value) : [...list, value],
+    );
+  };
+
+  return (
+    <aside className="sticky top-0 p-4 space-y-6 border-r border-border h-screen overflow-y-auto hidden md:block">
+      <div>
+        <h3 className="mb-2 text-background font-semibold">Chains</h3>
+        <div className="flex flex-wrap gap-2">
+          {chains.map((c) => (
+            <Button
+              key={c}
+              variant={selectedChains.includes(c) ? "primary" : "ghost"}
+              className="text-sm"
+              onClick={() => toggle(c, selectedChains, setSelectedChains)}
+            >
+              {c}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="mb-2 text-background font-semibold">Categories</h3>
+        <div className="flex flex-wrap gap-2">
+          {categories.map((c) => (
+            <Button
+              key={c}
+              variant={selectedCategories.includes(c) ? "primary" : "ghost"}
+              className="text-sm"
+              onClick={() =>
+                toggle(c, selectedCategories, setSelectedCategories)
+              }
+            >
+              {c}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="mb-2 text-background font-semibold">Sort By</h3>
+        <Dropdown options={sorts} value={sort} onChange={setSort} />
+      </div>
+    </aside>
+  );
+};
+
+export default FiltersSidebar;

--- a/packages/nextjs/components/ui/MintModal.tsx
+++ b/packages/nextjs/components/ui/MintModal.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import Button from "./Button";
+
+export const MintModal: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>Mint NFT</Button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-primary p-6 rounded-md w-96 space-y-4">
+            <h3 className="text-background font-semibold">Mint NFT</h3>
+            <input
+              type="text"
+              placeholder="Title"
+              className="w-full px-3 py-2 rounded-md bg-transparent border border-border text-background"
+            />
+            <input type="file" className="w-full text-background" />
+            <div className="flex gap-2 justify-end">
+              <Button variant="ghost" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button>Mint</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MintModal;

--- a/packages/nextjs/components/ui/NFTCard.tsx
+++ b/packages/nextjs/components/ui/NFTCard.tsx
@@ -1,0 +1,64 @@
+import Image from "next/image";
+import React from "react";
+import Avatar from "./Avatar";
+import Badge from "./Badge";
+import Button from "./Button";
+
+type NFTCardProps = {
+  title: string;
+  image: string;
+  creator: string;
+  price: string;
+  chainIcon: string;
+  badge?: { label: string; variant?: "verified" | "new" | "sale" };
+  actionLabel?: string;
+};
+
+export const NFTCard: React.FC<NFTCardProps> = ({
+  title,
+  image,
+  creator,
+  price,
+  chainIcon,
+  badge,
+  actionLabel = "Buy now",
+}) => (
+  <div className="group relative col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3">
+    <div className="relative w-full aspect-square overflow-hidden rounded-lg bg-base-300">
+      <Image
+        src={image}
+        alt={title}
+        fill
+        className="object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+        <Button>{actionLabel}</Button>
+      </div>
+      {badge && (
+        <div className="absolute top-2 left-2">
+          <Badge label={badge.label} variant={badge.variant} />
+        </div>
+      )}
+      <Image
+        src={chainIcon}
+        alt="chain"
+        width={20}
+        height={20}
+        className="absolute top-2 right-2"
+      />
+    </div>
+    <div className="mt-3 flex items-center justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-background truncate">
+          {title}
+        </p>
+        <div className="flex items-center gap-2 mt-1">
+          <Avatar src={creator} alt={title} size={24} />
+          <span className="text-xs text-background">{price}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default NFTCard;

--- a/packages/nextjs/components/ui/NFTDetail.tsx
+++ b/packages/nextjs/components/ui/NFTDetail.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image";
+import React, { useState } from "react";
+import Button from "./Button";
+
+const tabs = ["Overview", "Bids", "History"];
+
+export const NFTDetail: React.FC = () => {
+  const [active, setActive] = useState("Overview");
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
+      <div className="md:col-span-6">
+        <div className="relative w-full aspect-square overflow-hidden rounded-lg bg-base-300">
+          <Image src="/nft.png" alt="NFT" fill className="object-cover" />
+        </div>
+      </div>
+      <div className="md:col-span-6 space-y-6">
+        <div className="flex gap-4 border-b border-border">
+          {tabs.map((t) => (
+            <button
+              key={t}
+              onClick={() => setActive(t)}
+              className={`pb-2 text-sm font-semibold transition-colors ${
+                active === t
+                  ? "text-accent border-b-2 border-accent"
+                  : "text-background"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        {active === "Overview" && (
+          <div className="text-background space-y-2">
+            <p>Creator: 0x1234...abcd</p>
+            <p>Owner: 0xabcd...1234</p>
+            <p>Royalties: 5%</p>
+            <p>Chain: Ethereum</p>
+            <p>Token ID: #1</p>
+            <p>Properties: Legendary</p>
+          </div>
+        )}
+        {active === "Bids" && (
+          <div className="text-background">
+            <p className="caption">No bids yet.</p>
+          </div>
+        )}
+        {active === "History" && (
+          <div className="text-background">
+            <p className="caption">No history available.</p>
+          </div>
+        )}
+        <div className="flex gap-4 pt-4">
+          <Button>Buy Now</Button>
+          <Button variant="secondary">Place Bid</Button>
+          <Button variant="ghost">Make Offer</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NFTDetail;

--- a/packages/nextjs/components/ui/NFTGrid.tsx
+++ b/packages/nextjs/components/ui/NFTGrid.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+type GridProps = {
+  children: React.ReactNode;
+};
+
+export const NFTGrid: React.FC<GridProps> = ({ children }) => (
+  <div className="grid grid-cols-12 gap-4 md:gap-6">{children}</div>
+);
+
+export default NFTGrid;

--- a/packages/nextjs/components/ui/WalletModal.tsx
+++ b/packages/nextjs/components/ui/WalletModal.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import Button from "./Button";
+
+export const WalletModal: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [connected, setConnected] = useState(false);
+
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>
+        {connected ? "Wallet" : "Connect Wallet"}
+      </Button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-primary p-6 rounded-md w-80">
+            {connected ? (
+              <div className="space-y-4">
+                <p className="text-background">0x1234...abcd</p>
+                <Button onClick={() => setConnected(false)}>Disconnect</Button>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <p className="text-background">Connect your wallet</p>
+                <Button onClick={() => setConnected(true)}>Connect</Button>
+              </div>
+            )}
+            <Button
+              variant="ghost"
+              className="mt-4 w-full"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WalletModal;

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -1,16 +1,20 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
-
-
-:root,
-[data-theme] {
-  background: #000;
+:root {
+  --color-primary: #141416;
+  --color-accent: #3772ff;
+  --color-background: #f9fafb;
+  --color-border: #e5e7eb;
 }
 
 body {
   min-height: 100vh;
+  background-color: var(--color-primary);
+  color: var(--color-background);
+  font-family: "Inter", sans-serif;
 }
 
 h1,
@@ -19,10 +23,16 @@ h3,
 h4 {
   margin-bottom: 0.5rem;
   line-height: 1;
+  font-weight: 700;
 }
 
 p {
   margin: 1rem 0;
+  font-size: 16px;
+}
+
+.caption {
+  font-size: 12px;
 }
 
 .btn {

--- a/packages/nextjs/tailwind.config.ts
+++ b/packages/nextjs/tailwind.config.ts
@@ -232,6 +232,15 @@ module.exports = {
         "gradient-icon":
           "var(--gradient, linear-gradient(90deg, #42D2F1 0%, #B248DD 100%))",
       },
+      colors: {
+        primary: "#141416",
+        accent: "#3772FF",
+        background: "#F9FAFB",
+        border: "#E5E7EB",
+      },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
     },
   },
 };


### PR DESCRIPTION
## Summary
- define color tokens and Inter typography for dark themed marketplace
- implement reusable UI kit (buttons, avatars, badges, dropdowns, modals)
- add NFT card, grid with filters, and detail page layout

## Testing
- `yarn workspace @ss-2/nextjs format`
- `yarn next:lint`
- `yarn test:nextjs --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c2a4df7883248a5c2b84036515f1