### PR TITLE
Fix Starknet hook usage in pages

### DIFF
--- a/packages/nextjs/components/ui/NFTDetail.tsx
+++ b/packages/nextjs/components/ui/NFTDetail.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Image from "next/image";
 import React, { useState } from "react";
 import Button from "./Button";

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -1,0 +1,23 @@
+import type { AppProps } from "next/app";
+import { StarknetConfig, starkscan } from "@starknet-react/core";
+import { ThemeProvider } from "~~/components/ThemeProvider";
+import { appChains, connectors } from "~~/services/web3/connectors";
+import provider from "~~/services/web3/provider";
+import { ProgressBar } from "~~/components/scaffold-stark/ProgressBar";
+import "~~/styles/globals.css";
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider enableSystem>
+      <StarknetConfig
+        chains={appChains}
+        provider={provider}
+        connectors={connectors}
+        explorer={starkscan}
+      >
+        <ProgressBar />
+        <Component {...pageProps} />
+      </StarknetConfig>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap legacy pages with Starknet provider so hooks work during build
- mark NFTDetail as client component to satisfy Next.js

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891c4da99ac83248b86e9a251022f67