### PR TITLE
feat: add tournament card with prize details

### DIFF
--- a/packages/nextjs/components/MostPopularSection.tsx
+++ b/packages/nextjs/components/MostPopularSection.tsx
@@ -1,13 +1,14 @@
-import NFTCard from "./ui/NFTCard";
-import NFTGrid from "./ui/NFTGrid";
+import TournamentCard from "./ui/TournamentCard";
 
 const items = Array.from({ length: 8 }).map((_, i) => ({
   id: i,
   title: `Popular NFT ${i + 1}`,
   image: "/nft.png",
-  creator: "/logo.svg",
-  price: `${(i + 1) * 0.1} ETH`,
-  chainIcon: "/explorer-icon.svg",
+  creatorAvatar: "/logo.svg",
+  creatorName: `Creator ${i + 1}`,
+  date: `Aug ${10 + i}, 8:00 PM`,
+  price: 0.1 * (i + 1),
+  registered: 20 + i * 5,
 }));
 
 /**
@@ -19,12 +20,11 @@ export default function MostPopularSection() {
       <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
         Most Popular
       </h2>
-      <NFTGrid>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6 justify-items-center">
         {items.map((item) => (
-          <NFTCard key={item.id} {...item} />
+          <TournamentCard key={item.id} {...item} />
         ))}
-      </NFTGrid>
+      </div>
     </section>
   );
 }
-

--- a/packages/nextjs/components/ui/TournamentCard.tsx
+++ b/packages/nextjs/components/ui/TournamentCard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import Avatar from "./Avatar";
+import Button from "./Button";
+import TournamentDetailsModal, {
+  TournamentItem,
+} from "./TournamentDetailsModal";
+
+export type TournamentCardProps = TournamentItem;
+
+export default function TournamentCard(props: TournamentCardProps) {
+  const [open, setOpen] = useState(false);
+  const totalPrize = props.price * props.registered;
+
+  return (
+    <div className="max-w-[10rem] w-full">
+      <div className="relative w-full aspect-[63/88] overflow-hidden rounded-lg bg-base-300 border border-border">
+        <Image
+          src={props.image}
+          alt={props.title}
+          fill
+          className="object-cover"
+        />
+      </div>
+      <div className="mt-2 p-2 bg-primary/10 rounded-md border border-primary text-background">
+        <div className="flex items-center gap-2 mb-1">
+          <Avatar src={props.creatorAvatar} alt={props.creatorName} size={24} />
+          <span className="text-xs font-semibold truncate">
+            {props.creatorName}
+          </span>
+        </div>
+        <p className="text-xs mb-1">{props.date}</p>
+        <p className="text-xs mb-1">Price: {props.price} ETH</p>
+        <p className="text-xs mb-1">Registered: {props.registered}</p>
+        <p className="text-xs mb-2">Prize: {totalPrize.toFixed(2)} ETH</p>
+        <Button className="w-full" onClick={() => setOpen(true)}>
+          More Details
+        </Button>
+      </div>
+      {open && (
+        <TournamentDetailsModal
+          item={{ ...props, totalPrize }}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/nextjs/components/ui/TournamentDetailsModal.tsx
+++ b/packages/nextjs/components/ui/TournamentDetailsModal.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Avatar from "./Avatar";
+import Button from "./Button";
+import { calculatePrizeDistribution } from "../../utils/prizeDistribution";
+
+export type TournamentItem = {
+  title: string;
+  image: string;
+  creatorAvatar: string;
+  creatorName: string;
+  date: string;
+  price: number;
+  registered: number;
+  totalPrize: number;
+};
+
+type ModalProps = {
+  item: TournamentItem;
+  onClose: () => void;
+};
+
+export default function TournamentDetailsModal({ item, onClose }: ModalProps) {
+  const distribution = calculatePrizeDistribution(item.price, item.registered);
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-primary p-4 rounded-md w-96 max-w-full space-y-4 relative">
+        <button
+          aria-label="Close"
+          className="absolute top-2 right-2 text-background"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        <div className="relative w-full aspect-[63/88] overflow-hidden rounded-md border border-border">
+          <Image
+            src={item.image}
+            alt={item.title}
+            fill
+            className="object-cover"
+          />
+        </div>
+        <div className="text-background space-y-1">
+          <div className="flex items-center gap-2">
+            <Avatar src={item.creatorAvatar} alt={item.creatorName} size={32} />
+            <span className="font-semibold">{item.creatorName}</span>
+          </div>
+          <p>{item.date}</p>
+          <p>Price: {item.price} ETH</p>
+          <p>Registered: {item.registered}</p>
+          <p>Total Prize: {item.totalPrize.toFixed(2)} ETH</p>
+        </div>
+        <div className="text-background">
+          <h4 className="font-semibold mb-1">Prize Distribution</h4>
+          <ul className="text-sm max-h-32 overflow-y-auto space-y-1">
+            {distribution.map((p, i) => (
+              <li key={i}>
+                Place {i + 1}: {p.toFixed(2)} ETH
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="text-background">
+          <h4 className="font-semibold mb-1">Refund Policy</h4>
+          <p className="text-sm">
+            Refunds are available up until the tournament start time.
+          </p>
+        </div>
+        <div className="pt-2 flex justify-end">
+          <Button onClick={onClose} variant="secondary">
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/nextjs/utils/prizeDistribution.ts
+++ b/packages/nextjs/utils/prizeDistribution.ts
@@ -1,0 +1,13 @@
+export function calculatePrizeDistribution(
+  price: number,
+  players: number,
+): number[] {
+  const totalPrize = price * players;
+  const weights = Array.from({ length: players }, (_, i) => players - i);
+  const weightSum = (players * (players + 1)) / 2;
+  return weights.map((w) =>
+    parseFloat(((totalPrize * w) / weightSum).toFixed(2)),
+  );
+}
+
+export default calculatePrizeDistribution;


### PR DESCRIPTION
## Summary
- show smaller pokemon-sized NFTs with tournament information
- add modal with refund policy and prize distribution
- utility to compute prize splits

## Testing
- `yarn test:nextjs`
- `yarn next:check-types` *(fails: React element type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68920dd6e1348324867968f640be2b66