### PR TITLE
Align header and relocate play button

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -25,7 +25,6 @@ export const menuLinks: HeaderMenuLink[] = [
   { label: "How it Works", href: "/#how" },
   { label: "Top Tournaments", href: "/#tournaments" },
   { label: "Marketplace", href: "/#marketplace" },
-  { label: "Play", href: "/play" },
 ];
 
 export const HeaderMenuLinks = () => {
@@ -112,8 +111,8 @@ export const Header = () => {
   ]);
 
   return (
-    <div className=" lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2 flex-wrap gap-2">
-      <div className="navbar-start w-auto lg:w-1/2 -mr-2">
+    <div className=" lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between items-center z-20 px-0 sm:px-2 flex-wrap gap-2">
+      <div className="navbar-start w-auto lg:w-1/2 -mr-2 items-center">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <label
             tabIndex={0}
@@ -158,7 +157,7 @@ export const Header = () => {
           <HeaderMenuLinks />
         </ul>
       </div>
-      <div className="navbar-end flex-grow mr-2 gap-4">
+      <div className="navbar-end flex-grow mr-2 gap-4 items-center">
         {status === "connected" && !isDeployed ? (
           <span className="bg-[#8a45fc] text-[9px] p-1 text-white">
             Wallet Not Deployed

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -39,7 +39,6 @@ export default function HeroSection() {
             alt={s.title}
             className="w-full h-full object-cover"
           />
-
         </div>
       ))}
 
@@ -49,12 +48,20 @@ export default function HeroSection() {
         <h1 className="text-3xl md:text-5xl font-bold mb-4">
           {slides[index].title}
         </h1>
-        <a
-          href="/#mint"
-          className="px-6 py-3 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow hover:bg-yellow-300 transition-colors"
-        >
-          Buy NFT
-        </a>
+        <div className="flex gap-4">
+          <a
+            href="/play"
+            className="px-6 py-3 bg-[#8a45fc] text-white font-semibold rounded-lg shadow hover:bg-[#6e2ae4] transition-colors"
+          >
+            Play
+          </a>
+          <a
+            href="/#mint"
+            className="px-6 py-3 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow hover:bg-yellow-300 transition-colors"
+          >
+            Buy NFT
+          </a>
+        </div>
       </div>
 
       <button
@@ -87,4 +94,3 @@ export default function HeroSection() {
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- center header elements for consistent layout
- show Play call-to-action in hero instead of nav menu

## Testing
- `yarn next:lint`
- `CI=1 yarn test:nextjs` *(fails: No test files found)*
- `yarn next:check-types` *(fails: Property 'totalPrize' is missing in type 'TournamentItem')*

------
https://chatgpt.com/codex/tasks/task_e_6892179f9a68832483163daed3f141d0