### PR TITLE
Make tournament prize optional

### DIFF
--- a/packages/nextjs/components/ui/TournamentCard.tsx
+++ b/packages/nextjs/components/ui/TournamentCard.tsx
@@ -12,7 +12,7 @@ export type TournamentCardProps = TournamentItem;
 
 export default function TournamentCard(props: TournamentCardProps) {
   const [open, setOpen] = useState(false);
-  const totalPrize = props.price * props.registered;
+  const totalPrize = props.totalPrize ?? props.price * props.registered;
 
   return (
     <div className="max-w-[10rem] w-full">

--- a/packages/nextjs/components/ui/TournamentDetailsModal.tsx
+++ b/packages/nextjs/components/ui/TournamentDetailsModal.tsx
@@ -14,7 +14,11 @@ export type TournamentItem = {
   date: string;
   price: number;
   registered: number;
-  totalPrize: number;
+  /**
+   * Optionally include the total prize. If omitted, it will be derived from
+   * `price` and `registered` values.
+   */
+  totalPrize?: number;
 };
 
 type ModalProps = {
@@ -23,6 +27,7 @@ type ModalProps = {
 };
 
 export default function TournamentDetailsModal({ item, onClose }: ModalProps) {
+  const totalPrize = item.totalPrize ?? item.price * item.registered;
   const distribution = calculatePrizeDistribution(item.price, item.registered);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -50,7 +55,7 @@ export default function TournamentDetailsModal({ item, onClose }: ModalProps) {
           <p>{item.date}</p>
           <p>Price: {item.price} ETH</p>
           <p>Registered: {item.registered}</p>
-          <p>Total Prize: {item.totalPrize.toFixed(2)} ETH</p>
+          <p>Total Prize: {totalPrize.toFixed(2)} ETH</p>
         </div>
         <div className="text-background">
           <h4 className="font-semibold mb-1">Prize Distribution</h4>


### PR DESCRIPTION
## Summary
- compute tournament total prize from price and registrations when not provided
- pass computed prize to details modal and card

## Testing
- `npx tsc --noEmit`
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68921cfd80a88324ba485b10fd615d4f