### PR TITLE
feat: display seven nft cards in Most Popular

### DIFF
--- a/packages/nextjs/components/MostPopularSection.tsx
+++ b/packages/nextjs/components/MostPopularSection.tsx
@@ -1,6 +1,11 @@
-import PopularNftCard from "./ui/PopularNftCard";
+import {
+  PopularNftCard,
+  type PopularNftCardProps,
+} from "./ui/PopularNftCard";
 
-const items = Array.from({ length: 7 }).map((_, i) => ({
+type PopularNftItem = PopularNftCardProps & { id: number };
+
+const items: PopularNftItem[] = Array.from({ length: 7 }).map((_, i) => ({
   id: i,
   title: `PUNK${1000 + i}`,
   image: "/nft.png",

--- a/packages/nextjs/components/MostPopularSection.tsx
+++ b/packages/nextjs/components/MostPopularSection.tsx
@@ -1,14 +1,17 @@
-import TournamentCard from "./ui/TournamentCard";
+import PopularNftCard from "./ui/PopularNftCard";
 
-const items = Array.from({ length: 8 }).map((_, i) => ({
+const items = Array.from({ length: 7 }).map((_, i) => ({
   id: i,
-  title: `Popular NFT ${i + 1}`,
+  title: `PUNK${1000 + i}`,
   image: "/nft.png",
-  creatorAvatar: "/logo.svg",
-  creatorName: `Creator ${i + 1}`,
-  date: `Aug ${10 + i}, 8:00 PM`,
-  price: 0.1 * (i + 1),
-  registered: 20 + i * 5,
+  buyIn: `$${20 + i}`,
+  status: "Minting",
+  gameType: "No-Limit Texas Hold'em",
+  dateTime: `[2025.08.${12 + i} 21:00 GMT]`,
+  tournamentType: "Tournament",
+  registered: 9999 - i,
+  maxRegistered: 10000,
+  prize: "$200,000",
 }));
 
 /**
@@ -20,9 +23,9 @@ export default function MostPopularSection() {
       <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
         Most Popular
       </h2>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6 justify-items-center">
+      <div className="grid grid-cols-7 gap-6 justify-items-center">
         {items.map((item) => (
-          <TournamentCard key={item.id} {...item} />
+          <PopularNftCard key={item.id} {...item} />
         ))}
       </div>
     </section>

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import Image from "next/image";
+import type { FC } from "react";
 
 export interface PopularNftCardProps {
   image: string;
@@ -15,7 +14,7 @@ export interface PopularNftCardProps {
   prize: string;
 }
 
-export default function PopularNftCard({
+export const PopularNftCard: FC<PopularNftCardProps> = ({
   image,
   title,
   buyIn,
@@ -26,67 +25,67 @@ export default function PopularNftCard({
   registered,
   maxRegistered,
   prize,
-}: PopularNftCardProps) {
-  return (
-    <div className="max-w-xs w-full bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
-      <div className="aspect-square overflow-hidden">
-        <Image
-          src={image}
-          alt={title}
-          width={320}
-          height={320}
-          className="w-full h-full object-cover"
-        />
+}) => (
+  <div className="max-w-xs w-full bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
+    <div className="aspect-square overflow-hidden">
+      <Image
+        src={image}
+        alt={title}
+        width={320}
+        height={320}
+        className="w-full h-full object-cover"
+      />
+    </div>
+    <div className="px-4 pt-4 pb-2 space-y-1" />
+    <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
+      <div className="flex flex-col">
+        <h2 className="text-sm font-semibold text-gray-900 leading-tight">
+          {title}
+        </h2>
       </div>
-      <div className="px-4 pt-4 pb-2 space-y-1" />
-      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
-        <div className="flex flex-col">
-          <h2 className="text-sm font-semibold text-gray-900 leading-tight">
-            {title}
-          </h2>
-        </div>
-        <div className="text-right">
-          <span className="text-sm font-semibold text-gray-900 leading-tight">{`Buy-In ${buyIn}`}</span>
-        </div>
-      </div>
-      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
-        <div className="flex flex-col">
-          <span className="text-green-600 flex items-center gap-1">
-            <span className="w-2 h-2 bg-green-500 rounded-full inline-block" />
-            {status}
-          </span>
-          <div className="flex items-center text-xs text-gray-500 font-medium">
-            {gameType}
-          </div>
-        </div>
-        <div className="text-right">
-          <span className="ml-1 text-yellow-400">{dateTime}</span>
-          <br />
-          <span className="text-xs text-gray-500 font-medium">
-            {tournamentType}
-          </span>
-        </div>
-      </div>
-      <hr className="my-2 border-gray-100" />
-      <div className="px-4 pb-4 flex justify-between text-xs text-gray-600 font-medium">
-        <div className="flex flex-col">
-          <span className="text-green-600 flex items-center gap-1">
-            {`${registered.toLocaleString()} / ${maxRegistered.toLocaleString()}`}
-          </span>
-          <span className="text-gray-400">Registered</span>
-        </div>
-        <div className="text-right">
-          <span className="text-gray-900 flex font-bold">{prize}</span>
-          <span className="text-gray-400">PRIZE</span>
-        </div>
-      </div>
-      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium pb-4">
-        <div className="flex flex-col" />
-        <div className="text-right">
-          <span className="text-gray-400 mr-2">Rules</span>
-          <span className="text-gray-400">More</span>
-        </div>
+      <div className="text-right">
+        <span className="text-sm font-semibold text-gray-900 leading-tight">{`Buy-In ${buyIn}`}</span>
       </div>
     </div>
-  );
-}
+    <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
+      <div className="flex flex-col">
+        <span className="text-green-600 flex items-center gap-1">
+          <span className="w-2 h-2 bg-green-500 rounded-full inline-block" />
+          {status}
+        </span>
+        <div className="flex items-center text-xs text-gray-500 font-medium">
+          {gameType}
+        </div>
+      </div>
+      <div className="text-right">
+        <span className="ml-1 text-yellow-400">{dateTime}</span>
+        <br />
+        <span className="text-xs text-gray-500 font-medium">
+          {tournamentType}
+        </span>
+      </div>
+    </div>
+    <hr className="my-2 border-gray-100" />
+    <div className="px-4 pb-4 flex justify-between text-xs text-gray-600 font-medium">
+      <div className="flex flex-col">
+        <span className="text-green-600 flex items-center gap-1">
+          {`${registered.toLocaleString()} / ${maxRegistered.toLocaleString()}`}
+        </span>
+        <span className="text-gray-400">Registered</span>
+      </div>
+      <div className="text-right">
+        <span className="text-gray-900 flex font-bold">{prize}</span>
+        <span className="text-gray-400">PRIZE</span>
+      </div>
+    </div>
+    <div className="px-4 flex justify-between text-xs text-gray-600 font-medium pb-4">
+      <div className="flex flex-col" />
+      <div className="text-right">
+        <span className="text-gray-400 mr-2">Rules</span>
+        <span className="text-gray-400">More</span>
+      </div>
+    </div>
+  </div>
+);
+
+export default PopularNftCard;

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Image from "next/image";
+
+export interface PopularNftCardProps {
+  image: string;
+  title: string;
+  buyIn: string;
+  status: string;
+  gameType: string;
+  dateTime: string;
+  tournamentType: string;
+  registered: number;
+  maxRegistered: number;
+  prize: string;
+}
+
+export default function PopularNftCard({
+  image,
+  title,
+  buyIn,
+  status,
+  gameType,
+  dateTime,
+  tournamentType,
+  registered,
+  maxRegistered,
+  prize,
+}: PopularNftCardProps) {
+  return (
+    <div className="max-w-xs w-full bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
+      <div className="aspect-square overflow-hidden">
+        <Image
+          src={image}
+          alt={title}
+          width={320}
+          height={320}
+          className="w-full h-full object-cover"
+        />
+      </div>
+      <div className="px-4 pt-4 pb-2 space-y-1" />
+      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
+        <div className="flex flex-col">
+          <h2 className="text-sm font-semibold text-gray-900 leading-tight">
+            {title}
+          </h2>
+        </div>
+        <div className="text-right">
+          <span className="text-sm font-semibold text-gray-900 leading-tight">{`Buy-In ${buyIn}`}</span>
+        </div>
+      </div>
+      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium">
+        <div className="flex flex-col">
+          <span className="text-green-600 flex items-center gap-1">
+            <span className="w-2 h-2 bg-green-500 rounded-full inline-block" />
+            {status}
+          </span>
+          <div className="flex items-center text-xs text-gray-500 font-medium">
+            {gameType}
+          </div>
+        </div>
+        <div className="text-right">
+          <span className="ml-1 text-yellow-400">{dateTime}</span>
+          <br />
+          <span className="text-xs text-gray-500 font-medium">
+            {tournamentType}
+          </span>
+        </div>
+      </div>
+      <hr className="my-2 border-gray-100" />
+      <div className="px-4 pb-4 flex justify-between text-xs text-gray-600 font-medium">
+        <div className="flex flex-col">
+          <span className="text-green-600 flex items-center gap-1">
+            {`${registered.toLocaleString()} / ${maxRegistered.toLocaleString()}`}
+          </span>
+          <span className="text-gray-400">Registered</span>
+        </div>
+        <div className="text-right">
+          <span className="text-gray-900 flex font-bold">{prize}</span>
+          <span className="text-gray-400">PRIZE</span>
+        </div>
+      </div>
+      <div className="px-4 flex justify-between text-xs text-gray-600 font-medium pb-4">
+        <div className="flex flex-col" />
+        <div className="text-right">
+          <span className="text-gray-400 mr-2">Rules</span>
+          <span className="text-gray-400">More</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `PopularNftCard` component styled for NFT listings
- show a single row of seven NFT cards in the Most Popular section

## Testing
- `yarn next:lint`
- `yarn test:nextjs --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689222f46ab8832488ced796fb1f731f