### PR TITLE
feat: add sortable tournament table

### DIFF
--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -5,87 +5,171 @@ import { useState } from "react";
 type Tournament = {
   id: number;
   name: string;
+  creator: string;
+  creatorAvatar: string;
+  game: string;
+  buyIn: number;
+  sold: number;
+  prizes: string;
+  date: string;
+  supply: number;
   nft: string;
-  bank: number;
-  prize: string;
-  starts: string;
 };
 
-const tournaments: Tournament[] = Array.from({ length: 6 }).map((_, i) => ({
-  id: i,
-  name: `Tournament ${i + 1}`,
-  nft: "/nft.png",
-  bank: 1000 + i * 500,
-  prize: "40% / 30% / 20% / 10%",
-  starts: `${i + 1}h`,
-}));
+const tournaments: Tournament[] = [
+  {
+    id: 1,
+    name: "Saturday $200,000",
+    creator: "BAYC",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Hold'em",
+    buyIn: 100,
+    sold: 450,
+    prizes: "40% / 30% / 20% / 10%",
+    date: "2024-06-01",
+    supply: 1000,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 2,
+    name: "Saturday Million",
+    creator: "Cool Cats",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Omaha",
+    buyIn: 250,
+    sold: 300,
+    prizes: "50% / 30% / 20%",
+    date: "2024-06-15",
+    supply: 750,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 3,
+    name: "Sunday Showdown",
+    creator: "Doodles",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Hold'em",
+    buyIn: 50,
+    sold: 600,
+    prizes: "30% / 20% / 10%",
+    date: "2024-07-04",
+    supply: 1200,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+];
 
-/**
- * Table view of all tournaments with simple text filters.
- */
+type SortKey = keyof Tournament;
+
+const columns: { key: SortKey; label: string; numeric?: boolean }[] = [
+  { key: "name", label: "Tournament" },
+  { key: "creator", label: "Creator" },
+  { key: "game", label: "Game" },
+  { key: "buyIn", label: "Buy-In", numeric: true },
+  { key: "sold", label: "Sold", numeric: true },
+  { key: "prizes", label: "Prizes" },
+  { key: "date", label: "Date" },
+  { key: "supply", label: "Supply", numeric: true },
+  { key: "nft", label: "NFT" },
+];
+
 export default function TournamentsTableSection() {
-  const [search, setSearch] = useState("");
-  const [minBank, setMinBank] = useState("");
+  const [openColumn, setOpenColumn] = useState<SortKey | null>(null);
+  const [sortConfig, setSortConfig] = useState<{
+    key: SortKey;
+    direction: "asc" | "desc";
+  } | null>(null);
 
-  const filtered = tournaments.filter(
-    (t) =>
-      t.name.toLowerCase().includes(search.toLowerCase()) &&
-      (minBank ? t.bank >= parseInt(minBank, 10) : true),
-  );
+  const sorted = [...tournaments].sort((a, b) => {
+    if (!sortConfig) return 0;
+    const { key, direction } = sortConfig;
+    const aVal = a[key];
+    const bVal = b[key];
+    let comparison = 0;
+    if (typeof aVal === "number" && typeof bVal === "number") {
+      comparison = aVal - bVal;
+    } else {
+      comparison = String(aVal).localeCompare(String(bVal));
+    }
+    return direction === "asc" ? comparison : -comparison;
+  });
+
+  const toggleColumn = (key: SortKey) => {
+    setOpenColumn((prev) => (prev === key ? null : key));
+  };
+
+  const applySort = (key: SortKey, direction: "asc" | "desc") => {
+    setSortConfig({ key, direction });
+    setOpenColumn(null);
+  };
 
   return (
-    <section className="py-12 px-6 md:px-12">
-      <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
-        All Tournaments
-      </h2>
+    <section className="text-white p-8">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl font-bold mb-6">
+          Trending <span className="text-yellow-400">Top</span>
+        </h2>
 
-      <div className="flex flex-col md:flex-row gap-4 mb-6 justify-center">
-        <input
-          type="text"
-          placeholder="Search tournaments"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="px-3 py-2 border rounded-md w-full md:w-64 bg-white/5 text-white"
-        />
-        <input
-          type="number"
-          placeholder="Min bank"
-          value={minBank}
-          onChange={(e) => setMinBank(e.target.value)}
-          className="px-3 py-2 border rounded-md w-full md:w-40 bg-white/5 text-white"
-        />
-      </div>
-
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-left">
-          <thead>
-            <tr className="border-b border-white/10">
-              <th className="px-4 py-2">Tournament</th>
-              <th className="px-4 py-2">Bank</th>
-              <th className="px-4 py-2">Prize Distribution</th>
-              <th className="px-4 py-2">Starts</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((t) => (
-              <tr key={t.id} className="border-b border-white/5">
-                <td className="px-4 py-3 flex items-center gap-3">
-                  <img
-                    src={t.nft}
-                    alt={t.name}
-                    className="w-12 h-12 rounded-md object-cover"
-                  />
-                  <span>{t.name}</span>
-                </td>
-                <td className="px-4 py-3">{t.bank.toLocaleString()} ETH</td>
-                <td className="px-4 py-3">{t.prize}</td>
-                <td className="px-4 py-3">{t.starts}</td>
+        <div className="overflow-auto rounded-lg border border-gray-700">
+          <table className="min-w-full text-sm table-auto">
+            <thead className="bg-gray-900 text-gray-400 uppercase text-xs">
+              <tr>
+                {columns.map((col) => (
+                  <th key={col.key} className="px-4 py-3 text-left relative">
+                    <button
+                      className="flex items-center gap-1"
+                      onClick={() => toggleColumn(col.key)}
+                    >
+                      {col.label}
+                    </button>
+                    {openColumn === col.key && (
+                      <div className="absolute left-0 mt-1 w-32 bg-gray-800 rounded shadow-lg z-10">
+                        <button
+                          className="block w-full text-left px-3 py-1 hover:bg-gray-700"
+                          onClick={() => applySort(col.key, "asc")}
+                        >
+                          {col.numeric ? "Low → High" : "A → Z"}
+                        </button>
+                        <button
+                          className="block w-full text-left px-3 py-1 hover:bg-gray-700"
+                          onClick={() => applySort(col.key, "desc")}
+                        >
+                          {col.numeric ? "High → Low" : "Z → A"}
+                        </button>
+                      </div>
+                    )}
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="bg-black divide-y divide-gray-800">
+              {sorted.map((t) => (
+                <tr key={t.id} className="hover:bg-gray-900 transition">
+                  <td className="px-4 py-3 flex items-center gap-3">
+                    {t.name}
+                  </td>
+                  <td className="px-4 py-3 flex items-center gap-3">
+                    <img
+                      src={t.creatorAvatar}
+                      alt={t.creator}
+                      className="w-8 h-8 rounded-full"
+                    />
+                    <span>{t.creator}</span>
+                  </td>
+                  <td className="px-4 py-3">{t.game}</td>
+                  <td className="px-4 py-3 text-green-400">{t.buyIn}</td>
+                  <td className="px-4 py-3 text-orange-400">{t.sold}</td>
+                  <td className="px-4 py-3">{t.prizes}</td>
+                  <td className="px-4 py-3">{t.date}</td>
+                  <td className="px-4 py-3">{t.supply}</td>
+                  <td className="px-4 py-3">
+                    <img src={t.nft} alt={t.name} className="w-8 h-8" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- rebuild tournaments table using Tailwind styles
- add column dropdowns that sort tournaments by each field

## Testing
- `yarn next:lint`
- `yarn next:check-types`
- `yarn test:nextjs`

------
https://chatgpt.com/codex/tasks/task_e_6892305467e48324bc47ef39d8f95e82