### PR TITLE
chore: resolve build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ package-lock.json
 .eslintcache
 .DS_Store
 .vercel
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/packages/nextjs/components/Card.tsx
+++ b/packages/nextjs/components/Card.tsx
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 // src/components/Card.tsx
+import Image from "next/image";
 import clsx from "clsx";
 import type { Card as TCard } from "../game/types"; // type-only ✔
 import cardStarknet from "../assets/svg-cards/card-starknet.svg";
@@ -47,7 +48,7 @@ interface Props {
 }
 
 export default function Card({ card, hidden, size = "md" }: Props) {
-  const className = clsx("relative rounded-md shadow-sm", {
+  const className = clsx("rounded-md shadow-sm", {
     "w-16 h-24": size === "sm",
     "w-20 h-28": size === "md",
     "w-24 h-32": size === "lg",
@@ -57,5 +58,16 @@ export default function Card({ card, hidden, size = "md" }: Props) {
   const src =
     hidden || !card ? cardStarknet : (faceSvgs[faceKey(card)] ?? cardStarknet); // fallback to back if missing
 
-  return <img src={src} className={className} draggable={false} />;
+  const alt = hidden || !card ? "Card back" : `${card.rank} of ${card.suit}`;
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      className={className}
+      draggable={false}
+      width={80}
+      height={120}
+    />
+  );
 }

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useState } from "react";
 
 const slides = [
-  { id: 0, title: "Featured NFT 1", image: "carousel/pokernfts1.png" },
-  { id: 1, title: "Featured NFT 2", image: "carousel/pokernfts2.png" },
-  { id: 2, title: "Featured NFT 3", image: "carousel/pokernfts3.png" },
-  { id: 3, title: "Featured NFT 3", image: "carousel/pokernfts4.png" },
+  { id: 0, title: "Featured NFT 1", image: "/carousel/pokernfts1.png" },
+  { id: 1, title: "Featured NFT 2", image: "/carousel/pokernfts2.png" },
+  { id: 2, title: "Featured NFT 3", image: "/carousel/pokernfts3.png" },
+  { id: 3, title: "Featured NFT 3", image: "/carousel/pokernfts4.png" },
 ];
 
 /**
@@ -35,10 +36,12 @@ export default function HeroSection() {
             i === index ? "opacity-100" : "opacity-0"
           }`}
         >
-          <img
+          <Image
             src={s.image}
             alt={s.title}
-            className="w-full h-full object-cover"
+            fill
+            priority={i === index}
+            className="object-cover"
           />
         </div>
       ))}

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 
 type Tournament = {
@@ -70,9 +71,11 @@ export default function TournamentsTableSection() {
             {filtered.map((t) => (
               <tr key={t.id} className="border-b border-white/5">
                 <td className="px-4 py-3 flex items-center gap-3">
-                  <img
+                  <Image
                     src={t.nft}
                     alt={t.name}
+                    width={48}
+                    height={48}
                     className="w-12 h-12 rounded-md object-cover"
                   />
                   <span>{t.name}</span>

--- a/packages/nextjs/services/starknet.ts
+++ b/packages/nextjs/services/starknet.ts
@@ -32,7 +32,8 @@ async function loadContract(
 ): Promise<Contract> {
   if (!provider) throw new Error("Starknet provider not initialized");
   try {
-    const abi: Abi = (await import(/* @vite-ignore */ abiPath)).default;
+    const res = await fetch(abiPath);
+    const abi: Abi = await res.json();
     return new Contract(abi, address, account || provider);
   } catch (err) {
     console.error("Failed to load contract", err);


### PR DESCRIPTION
## Summary
- ignore environment files in version control
- replace `img` tags with optimized `next/image` usage
- load contract ABIs via fetch to avoid dynamic import warnings

## Testing
- `yarn next:lint`
- `yarn next:check-types && echo 'Type check passed'`
- `yarn build:next` *(fails: Failed to patch lockfile, please try uninstalling and reinstalling next in this workspace - ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68923274a3d08324b3bf6fcd8e7f181e