### PR TITLE
feat: improve responsive layout and tables

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -6,14 +6,8 @@ import Table from "../../components/Table";
 import { useGameStore } from "../../hooks/useGameStore";
 
 export default function PlayPage() {
-  const {
-    street,
-    reloadTableState,
-    startHand,
-    dealFlop,
-    dealTurn,
-    dealRiver,
-  } = useGameStore();
+  const { street, reloadTableState, startHand, dealFlop, dealTurn, dealRiver } =
+    useGameStore();
 
   const [isJoining, setIsJoining] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,7 +32,6 @@ export default function PlayPage() {
   async function handleJoinTable() {
     setError(null);
     setIsJoining(true);
-
   }
 
   return (

--- a/packages/nextjs/components/ActionBar.tsx
+++ b/packages/nextjs/components/ActionBar.tsx
@@ -7,7 +7,13 @@ interface Props {
   onRiver: () => void;
 }
 
-export default function ActionBar({ street, onStart, onFlop, onTurn, onRiver }: Props) {
+export default function ActionBar({
+  street,
+  onStart,
+  onFlop,
+  onTurn,
+  onRiver,
+}: Props) {
   return (
     <div className="flex gap-4">
       {street === 0 && (

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -33,9 +33,7 @@ export const Footer = () => {
         <ul className="menu menu-horizontal w-full">
           <div className="flex justify-center items-center gap-2 text-sm w-full">
             <div className="text-center">
-              <p>
-                All rights reserved © 2025
-              </p>
+              <p>All rights reserved © 2025</p>
             </div>
           </div>
         </ul>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -111,7 +111,7 @@ export const Header = () => {
   ]);
 
   return (
-    <div className=" lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between items-center z-20 px-0 sm:px-2 flex-wrap gap-2">
+    <div className="lg:static top-0 navbar min-h-0 flex-shrink-0 justify-between items-center z-20 px-0 sm:px-2 gap-2 flex-nowrap bg-base-100/60 backdrop-blur">
       <div className="navbar-start w-auto lg:w-1/2 -mr-2 items-center">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <label
@@ -157,7 +157,7 @@ export const Header = () => {
           <HeaderMenuLinks />
         </ul>
       </div>
-      <div className="navbar-end flex-grow mr-2 gap-4 items-center">
+      <div className="navbar-end ml-auto mr-2 gap-4 items-center flex-nowrap">
         {status === "connected" && !isDeployed ? (
           <span className="bg-[#8a45fc] text-[9px] p-1 text-white">
             Wallet Not Deployed

--- a/packages/nextjs/components/MarketplaceSection.tsx
+++ b/packages/nextjs/components/MarketplaceSection.tsx
@@ -13,9 +13,9 @@ const items = Array.from({ length: 8 }).map((_, i) => ({
 
 export default function MarketplaceSection() {
   return (
-    <section className="py-12">
+    <section className="py-12 px-4 sm:px-6">
       <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-6">
-        <div className="md:col-span-3">
+        <div className="md:col-span-3 mb-6 md:mb-0">
           <FiltersSidebar />
         </div>
         <div className="md:col-span-9">

--- a/packages/nextjs/components/MostPopularSection.tsx
+++ b/packages/nextjs/components/MostPopularSection.tsx
@@ -1,7 +1,4 @@
-import {
-  PopularNftCard,
-  type PopularNftCardProps,
-} from "./ui/PopularNftCard";
+import { PopularNftCard, type PopularNftCardProps } from "./ui/PopularNftCard";
 
 type PopularNftItem = PopularNftCardProps & { id: number };
 
@@ -24,11 +21,11 @@ const items: PopularNftItem[] = Array.from({ length: 5 }).map((_, i) => ({
  */
 export default function MostPopularSection() {
   return (
-    <section className="py-12 px-6 md:px-12">
+    <section className="py-12 px-4 sm:px-6 md:px-12">
       <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
         Most Popular
       </h2>
-      <div className="grid grid-cols-5 gap-6 justify-items-center">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 md:gap-6 justify-items-center">
         {items.map((item) => (
           <PopularNftCard key={item.id} {...item} />
         ))}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -41,4 +41,3 @@ export default function Table() {
     </section>
   );
 }
-

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useState } from "react";
 
 type Tournament = {
@@ -57,11 +56,77 @@ const tournaments: Tournament[] = [
     supply: 1200,
     nft: "https://placehold.co/220x320.png?text=NFT",
   },
+  {
+    id: 4,
+    name: "Nightly Brawl",
+    creator: "CryptoPunks",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Hold'em",
+    buyIn: 75,
+    sold: 500,
+    prizes: "40% / 30% / 20% / 10%",
+    date: "2024-07-20",
+    supply: 900,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 5,
+    name: "High Roller",
+    creator: "Azuki",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Omaha",
+    buyIn: 500,
+    sold: 120,
+    prizes: "60% / 25% / 15%",
+    date: "2024-08-05",
+    supply: 400,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 6,
+    name: "Daily Spin",
+    creator: "Moonbirds",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Hold'em",
+    buyIn: 25,
+    sold: 800,
+    prizes: "25% / 15% / 10%",
+    date: "2024-08-20",
+    supply: 1500,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 7,
+    name: "Weekend Warriors",
+    creator: "Pudgy Penguins",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Omaha",
+    buyIn: 150,
+    sold: 350,
+    prizes: "35% / 25% / 15% / 10%",
+    date: "2024-09-02",
+    supply: 600,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
+  {
+    id: 8,
+    name: "Grand Finale",
+    creator: "CloneX",
+    creatorAvatar: "https://placehold.co/320x320.png?text=NFT",
+    game: "Hold'em",
+    buyIn: 1000,
+    sold: 80,
+    prizes: "50% / 30% / 20%",
+    date: "2024-09-30",
+    supply: 200,
+    nft: "https://placehold.co/220x320.png?text=NFT",
+  },
 ];
 
 type SortKey = keyof Tournament;
 
 const columns: { key: SortKey; label: string; numeric?: boolean }[] = [
+  { key: "nft", label: "NFT" },
   { key: "name", label: "Tournament" },
   { key: "creator", label: "Creator" },
   { key: "game", label: "Game" },
@@ -70,7 +135,6 @@ const columns: { key: SortKey; label: string; numeric?: boolean }[] = [
   { key: "prizes", label: "Prizes" },
   { key: "date", label: "Date" },
   { key: "supply", label: "Supply", numeric: true },
-  { key: "nft", label: "NFT" },
 ];
 
 export default function TournamentsTableSection() {
@@ -104,17 +168,17 @@ export default function TournamentsTableSection() {
   };
 
   return (
-    <section className="text-white p-8">
+    <section className="text-white p-4 sm:p-8">
       <div className="max-w-6xl mx-auto">
         <h2 className="text-3xl font-bold mb-6">
           Trending <span className="text-yellow-400">Top</span>
         </h2>
         <div className="overflow-auto rounded-lg border border-gray-700">
-          <table className="min-w-full text-sm table-auto">
-            <thead className="bg-gray-900 text-gray-400 uppercase text-xs">
+          <table className="min-w-full text-xs sm:text-sm table-auto">
+            <thead className="bg-gray-900 text-gray-400 uppercase text-[10px] sm:text-xs">
               <tr>
                 {columns.map((col) => (
-                  <th key={col.key} className="px-4 py-3 text-left relative">
+                  <th key={col.key} className="px-2 py-2 text-left relative">
                     <button
                       className="flex items-center gap-1"
                       onClick={() => toggleColumn(col.key)}
@@ -144,30 +208,37 @@ export default function TournamentsTableSection() {
             <tbody className="bg-black divide-y divide-gray-800">
               {sorted.map((t) => (
                 <tr key={t.id} className="hover:bg-gray-900 transition">
-                  <td className="px-4 py-3 flex items-center gap-3">
-                    {t.name}
+                  <td className="px-2 py-2">
+                    <img
+                      src={t.nft}
+                      alt={t.name}
+                      className="w-12 h-12 object-cover rounded"
+                    />
                   </td>
-                  <td className="px-4 py-3 flex items-center gap-3">
+                  <td className="px-2 py-2">{t.name}</td>
+                  <td className="px-2 py-2 flex items-center gap-2">
                     <img
                       src={t.creatorAvatar}
                       alt={t.creator}
-                      className="w-8 h-8 rounded-full"
+                      className="w-6 h-6 rounded-full"
                     />
                     <span>{t.creator}</span>
                   </td>
-                  <td className="px-4 py-3">{t.game}</td>
-                  <td className="px-4 py-3 text-green-400">{t.buyIn}</td>
-                  <td className="px-4 py-3 text-orange-400">{t.sold}</td>
-                  <td className="px-4 py-3">{t.prizes}</td>
-                  <td className="px-4 py-3">{t.date}</td>
-                  <td className="px-4 py-3">{t.supply}</td>
-                  <td className="px-4 py-3">
-                    <img src={t.nft} alt={t.name} className="w-8 h-8" />
-                  </td>
+                  <td className="px-2 py-2">{t.game}</td>
+                  <td className="px-2 py-2 text-green-400">{t.buyIn}</td>
+                  <td className="px-2 py-2 text-orange-400">{t.sold}</td>
+                  <td className="px-2 py-2">{t.prizes}</td>
+                  <td className="px-2 py-2">{t.date}</td>
+                  <td className="px-2 py-2">{t.supply}</td>
                 </tr>
               ))}
             </tbody>
           </table>
+        </div>
+        <div className="flex justify-end mt-4">
+          <button className="px-4 py-2 text-xs sm:text-sm bg-[#8a45fc] text-white rounded">
+            [MORE]
+          </button>
         </div>
       </div>
     </section>

--- a/packages/nextjs/components/ui/NFTCard.tsx
+++ b/packages/nextjs/components/ui/NFTCard.tsx
@@ -23,8 +23,8 @@ export const NFTCard: React.FC<NFTCardProps> = ({
   badge,
   actionLabel = "Buy now",
 }) => (
-  <div className="group relative col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-3">
-    <div className="relative w-full aspect-square overflow-hidden rounded-lg bg-base-300">
+  <div className="group relative w-48 sm:w-56 flex-shrink-0">
+    <div className="relative w-48 h-48 sm:w-56 sm:h-56 overflow-hidden rounded-lg bg-base-300">
       <Image
         src={image}
         alt={title}

--- a/packages/nextjs/components/ui/NFTGrid.tsx
+++ b/packages/nextjs/components/ui/NFTGrid.tsx
@@ -5,7 +5,7 @@ type GridProps = {
 };
 
 export const NFTGrid: React.FC<GridProps> = ({ children }) => (
-  <div className="grid grid-cols-12 gap-4 md:gap-6">{children}</div>
+  <div className="flex flex-wrap justify-center gap-4 md:gap-6">{children}</div>
 );
 
 export default NFTGrid;

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -26,13 +26,13 @@ export const PopularNftCard: FC<PopularNftCardProps> = ({
   maxRegistered,
   prize,
 }) => (
-  <div className="max-w-xs w-full bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
-    <div className="aspect-square overflow-hidden">
+  <div className="w-48 sm:w-64 bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
+    <div className="relative w-48 h-48 sm:w-64 sm:h-64 overflow-hidden">
       <Image
         src={image}
         alt={title}
-        width={320}
-        height={320}
+        width={256}
+        height={256}
         className="w-full h-full object-cover"
       />
     </div>
@@ -79,11 +79,10 @@ export const PopularNftCard: FC<PopularNftCardProps> = ({
       </div>
     </div>
     <div className="px-2 flex justify-between text-xs text-gray-600 font-medium pb-4">
-      <div className="flex flex-col">
+      <div className="flex flex-col"></div>
+      <div className="text-right">
+        <span className="text-gray-400">Rules</span>
       </div>
-        <div className="text-right">
-          <span className="text-gray-400">Rules</span>
-        </div>
     </div>
   </div>
 );

--- a/packages/nextjs/game/constants.ts
+++ b/packages/nextjs/game/constants.ts
@@ -1,18 +1,35 @@
 // src/game/constants.ts
-import type { Rank, Suit } from './types';
+import type { Rank, Suit } from "./types";
 
 /** Card ordering (low → high) */
 export const RANKS: Rank[] = [
-  '2', '3', '4', '5', '6',
-  '7', '8', '9', 'T', 'J', 'Q', 'K', 'A',
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "T",
+  "J",
+  "Q",
+  "K",
+  "A",
 ];
 
-export const SUITS: Suit[] = ['♠', '♥', '♦', '♣'];
+export const SUITS: Suit[] = ["♠", "♥", "♦", "♣"];
 
 /** Blind levels (edit to taste) */
 export const SMALL_BLIND = 5;
-export const BIG_BLIND   = 10;
+export const BIG_BLIND = 10;
 
 /** Streets in order */
-export const STREETS = ['preflop', 'flop', 'turn', 'river', 'showdown'] as const;
-export type Street = typeof STREETS[number];
+export const STREETS = [
+  "preflop",
+  "flop",
+  "turn",
+  "river",
+  "showdown",
+] as const;
+export type Street = (typeof STREETS)[number];

--- a/packages/nextjs/game/utils.ts
+++ b/packages/nextjs/game/utils.ts
@@ -1,14 +1,12 @@
 // src/game/utils.ts
-import { RANKS, SUITS } from './constants';
-import type { Card } from './types';
+import { RANKS, SUITS } from "./constants";
+import type { Card } from "./types";
 
 /* ─────────── Random + Deck helpers ─────────── */
 
 export function freshDeck(): Card[] {
   const deck: Card[] = [];
-  for (const suit of SUITS)
-    for (const rank of RANKS)
-      deck.push({ rank, suit });
+  for (const suit of SUITS) for (const rank of RANKS) deck.push({ rank, suit });
   return shuffle(deck);
 }
 
@@ -24,7 +22,7 @@ export function shuffle<T>(array: T[]): T[] {
 /** Draws & returns the **top** card (mutates deck) */
 export function draw(deck: Card[]): Card {
   const card = deck.pop();
-  if (!card) throw new Error('Deck underflow');
+  if (!card) throw new Error("Deck underflow");
   return card;
 }
 
@@ -36,14 +34,14 @@ export function draw(deck: Card[]): Card {
    ---------------------------------------- */
 
 export interface RankedHand {
-  rankValue: number;    // lower = better (1 = Royal Flush)
-  bestCards: Card[];    // the 5-card best hand
+  rankValue: number; // lower = better (1 = Royal Flush)
+  bestCards: Card[]; // the 5-card best hand
 }
 
 /** Naïve fallback: high-card only.  Safe to replace later. */
 export function rankHand(sevenCards: Card[]): RankedHand {
   const sorted = [...sevenCards].sort(
-    (a, b) => RANKS.indexOf(b.rank) - RANKS.indexOf(a.rank)
+    (a, b) => RANKS.indexOf(b.rank) - RANKS.indexOf(a.rank),
   );
   return { rankValue: 10, bestCards: sorted.slice(0, 5) }; // 10 = "high card"
 }
@@ -54,8 +52,7 @@ export function compareHands(a: RankedHand, b: RankedHand): number {
   // tie-breaker: compare best card ranks
   for (let i = 0; i < 5; i++) {
     const diff =
-      RANKS.indexOf(b.bestCards[i].rank) -
-      RANKS.indexOf(a.bestCards[i].rank);
+      RANKS.indexOf(b.bestCards[i].rank) - RANKS.indexOf(a.bestCards[i].rank);
     if (diff !== 0) return diff;
   }
   return 0;

--- a/packages/nextjs/index.html
+++ b/packages/nextjs/index.html
@@ -1,35 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
+  <head>
+    <title>Poker NFTs</title>
+    <style>
+      .card {
+        width: 300px;
+        height: 420px;
+        border-radius: 20px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+        overflow: hidden;
+        font-family: "Arial", sans-serif;
+        background: #2e45f3;
+      }
 
-<head>
-  <title>Poker NFTs</title>
-  <style>
-    .card {
-      width: 300px;
-      height: 420px;
-      border-radius: 20px;
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-      overflow: hidden;
-      font-family: 'Arial', sans-serif;
-      background: #2e45f3;
-    }
+      svg text {
+        fill: #000;
+        pointer-events: none;
+      }
 
-    svg text {
-      fill: #000;
-      pointer-events: none;
-    }
+      .reflection {
+        pointer-events: none;
+      }
+    </style>
+  </head>
 
-    .reflection {
-      pointer-events: none;
-    }
-  </style>
-</head>
-
-<body>
-
-
-
-
-</body>
-
+  <body></body>
 </html>

--- a/packages/nextjs/public/sw.js
+++ b/packages/nextjs/public/sw.js
@@ -1,1 +1,424 @@
-if(!self.define){let e,s={};const n=(n,i)=>(n=new URL(n+".js",i).href,s[n]||new Promise(s=>{if("document"in self){const e=document.createElement("script");e.src=n,e.onload=s,document.head.appendChild(e)}else e=n,importScripts(n),s()}).then(()=>{let e=s[n];if(!e)throw new Error(`Module ${n} didn’t register its module`);return e}));self.define=(i,a)=>{const c=e||("document"in self?document.currentScript.src:"")||location.href;if(s[c])return;let t={};const r=e=>n(e,c),o={module:{uri:c},exports:t,require:r};s[c]=Promise.all(i.map(e=>o[e]||r(e))).then(e=>(a(...e),t))}}define(["./workbox-4754cb34"],function(e){"use strict";importScripts(),self.skipWaiting(),e.clientsClaim(),e.precacheAndRoute([{url:"/_next/app-build-manifest.json",revision:"36a0cdf6ae322262f23b16197d3a65ce"},{url:"/_next/static/XxFJg-OXMBUYQ14-j1Lfd/_buildManifest.js",revision:"deaf7a6bf19c921481c942e443baf65c"},{url:"/_next/static/XxFJg-OXMBUYQ14-j1Lfd/_ssgManifest.js",revision:"b6652df95db52feb4daf4eca35380933"},{url:"/_next/static/chunks/13-3386f5054ecc9220.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/144-d83e41ee9fbaa5f5.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/23-6c3203a2e7a7f40f.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/259-4d08fd6c2516db28.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/2f0b94e8-d5409678aa4d22ff.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/312-2d1ad6c47b114654.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/473f56c0-579879790f6981fb.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/532-ede25c9d674cc7a1.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/607-826855f427b09d5f.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/620.460c92bba75c2028.js",revision:"460c92bba75c2028"},{url:"/_next/static/chunks/648-5ebae018117d863a.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/695-93860c5215529c65.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/70646a03-03402d8e6763d3b8.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/743-25ef4170318c86ec.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/790-bb67bb589f747317.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/8e1d74a4-f42fa9939b8c6467.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/_not-found/page-c8820970c4b2fd5b.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/configure/page-789aefbacbe8b2cd.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/debug/page-8cb05c3a2c15f53b.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/layout-c744cf0791a46226.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/nft/%5Bid%5D/page-0fd35490ff6ffb89.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/page-996ae466a78a934e.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/app/play/page-d845373f86e18731.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/cb355538-ec6cdf481a292eea.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/e6909d18-5230cc3ec3f60e86.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/fd9d1056-a75d287af9d68cfc.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/framework-10c5a3a36623554f.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/main-97f8d15e45fabe94.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/main-app-5886811b5e274760.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/pages/HomePage-51d22054bb7358f4.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/pages/HomeTables-6a2076116883bbb4.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/pages/_app-9e9b8993d349c2ae.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/pages/_error-1be831200e60c5c0.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/chunks/polyfills-78c92fac7aa8fdd8.js",revision:"79330112775102f91e1010318bae2bd3"},{url:"/_next/static/chunks/webpack-34e15e5ec3c05453.js",revision:"XxFJg-OXMBUYQ14-j1Lfd"},{url:"/_next/static/css/b76e2b58b2186194.css",revision:"b76e2b58b2186194"},{url:"/blast-icon-color.svg",revision:"f455c22475a343be9fcd764de7e7147e"},{url:"/debug-icon.svg",revision:"25aadc709736507034d14ca7aabcd29d"},{url:"/debug-image.png",revision:"34c4ca2676dd59ff24d6338faa1af371"},{url:"/explorer-icon.svg",revision:"84507da0e8989bb5b7616a3f66d31f48"},{url:"/gradient-s.svg",revision:"c003f595a6d30b1b476115f64476e2cf"},{url:"/logo.ico",revision:"3d10c9692073e77d925595322ae24c04"},{url:"/logo.svg",revision:"13a19d77a1c682993b7c4fa9254a143a"},{url:"/manifest.json",revision:"781788f3e2bc4b2b176b5d8c425d7475"},{url:"/nft-art.png",revision:"14f53c64738877b3fa88aab9a910979b"},{url:"/nft.png",revision:"d03c88ded58792ce4abda0659221ef4a"},{url:"/poker.png",revision:"b9449effe384bcadd1ec623a59abfbe6"},{url:"/poker.svg",revision:"9988ce4f9f7a583858e6331f21515d2c"},{url:"/pokerboots.svg",revision:"9988ce4f9f7a583858e6331f21515d2c"},{url:"/rpc-version.png",revision:"cf97fd668cfa1221bec0210824978027"},{url:"/scaffold-config.png",revision:"1ebfc244c31732dc4273fe292bd07596"},{url:"/sn-symbol-gradient.png",revision:"908b60a4f6b92155b8ea38a009fa7081"},{url:"/starkcompass-icon.svg",revision:"eccc2ece017ee9e73e512996b74e49ac"},{url:"/voyager-icon.svg",revision:"06663dd5ba2c49423225a8e3893b45fe"}],{ignoreURLParametersMatching:[]}),e.cleanupOutdatedCaches(),e.registerRoute("/",new e.NetworkFirst({cacheName:"start-url",plugins:[{cacheWillUpdate:async({request:e,response:s,event:n,state:i})=>s&&"opaqueredirect"===s.type?new Response(s.body,{status:200,statusText:"OK",headers:s.headers}):s}]}),"GET"),e.registerRoute(/^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,new e.CacheFirst({cacheName:"google-fonts-webfonts",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:31536e3})]}),"GET"),e.registerRoute(/^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,new e.StaleWhileRevalidate({cacheName:"google-fonts-stylesheets",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:604800})]}),"GET"),e.registerRoute(/\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,new e.StaleWhileRevalidate({cacheName:"static-font-assets",plugins:[new e.ExpirationPlugin({maxEntries:4,maxAgeSeconds:604800})]}),"GET"),e.registerRoute(/\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,new e.StaleWhileRevalidate({cacheName:"static-image-assets",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\/_next\/image\?url=.+$/i,new e.StaleWhileRevalidate({cacheName:"next-image",plugins:[new e.ExpirationPlugin({maxEntries:64,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:mp3|wav|ogg)$/i,new e.CacheFirst({cacheName:"static-audio-assets",plugins:[new e.RangeRequestsPlugin,new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:mp4)$/i,new e.CacheFirst({cacheName:"static-video-assets",plugins:[new e.RangeRequestsPlugin,new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:js)$/i,new e.StaleWhileRevalidate({cacheName:"static-js-assets",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:css|less)$/i,new e.StaleWhileRevalidate({cacheName:"static-style-assets",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\/_next\/data\/.+\/.+\.json$/i,new e.StaleWhileRevalidate({cacheName:"next-data",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(/\.(?:json|xml|csv)$/i,new e.NetworkFirst({cacheName:"static-data-assets",plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(({url:e})=>{if(!(self.origin===e.origin))return!1;const s=e.pathname;return!s.startsWith("/api/auth/")&&!!s.startsWith("/api/")},new e.NetworkFirst({cacheName:"apis",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:16,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(({url:e})=>{if(!(self.origin===e.origin))return!1;return!e.pathname.startsWith("/api/")},new e.NetworkFirst({cacheName:"others",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:86400})]}),"GET"),e.registerRoute(({url:e})=>!(self.origin===e.origin),new e.NetworkFirst({cacheName:"cross-origin",networkTimeoutSeconds:10,plugins:[new e.ExpirationPlugin({maxEntries:32,maxAgeSeconds:3600})]}),"GET")});
+if (!self.define) {
+  let e,
+    s = {};
+  const n = (n, i) => (
+    (n = new URL(n + ".js", i).href),
+    s[n] ||
+      new Promise((s) => {
+        if ("document" in self) {
+          const e = document.createElement("script");
+          ((e.src = n), (e.onload = s), document.head.appendChild(e));
+        } else ((e = n), importScripts(n), s());
+      }).then(() => {
+        let e = s[n];
+        if (!e) throw new Error(`Module ${n} didn’t register its module`);
+        return e;
+      })
+  );
+  self.define = (i, a) => {
+    const c =
+      e ||
+      ("document" in self ? document.currentScript.src : "") ||
+      location.href;
+    if (s[c]) return;
+    let t = {};
+    const r = (e) => n(e, c),
+      o = { module: { uri: c }, exports: t, require: r };
+    s[c] = Promise.all(i.map((e) => o[e] || r(e))).then((e) => (a(...e), t));
+  };
+}
+define(["./workbox-4754cb34"], function (e) {
+  "use strict";
+  (importScripts(),
+    self.skipWaiting(),
+    e.clientsClaim(),
+    e.precacheAndRoute(
+      [
+        {
+          url: "/_next/app-build-manifest.json",
+          revision: "36a0cdf6ae322262f23b16197d3a65ce",
+        },
+        {
+          url: "/_next/static/XxFJg-OXMBUYQ14-j1Lfd/_buildManifest.js",
+          revision: "deaf7a6bf19c921481c942e443baf65c",
+        },
+        {
+          url: "/_next/static/XxFJg-OXMBUYQ14-j1Lfd/_ssgManifest.js",
+          revision: "b6652df95db52feb4daf4eca35380933",
+        },
+        {
+          url: "/_next/static/chunks/13-3386f5054ecc9220.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/144-d83e41ee9fbaa5f5.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/23-6c3203a2e7a7f40f.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/259-4d08fd6c2516db28.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/2f0b94e8-d5409678aa4d22ff.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/312-2d1ad6c47b114654.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/473f56c0-579879790f6981fb.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/532-ede25c9d674cc7a1.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/607-826855f427b09d5f.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/620.460c92bba75c2028.js",
+          revision: "460c92bba75c2028",
+        },
+        {
+          url: "/_next/static/chunks/648-5ebae018117d863a.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/695-93860c5215529c65.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/70646a03-03402d8e6763d3b8.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/743-25ef4170318c86ec.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/790-bb67bb589f747317.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/8e1d74a4-f42fa9939b8c6467.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/_not-found/page-c8820970c4b2fd5b.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/configure/page-789aefbacbe8b2cd.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/debug/page-8cb05c3a2c15f53b.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/layout-c744cf0791a46226.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/nft/%5Bid%5D/page-0fd35490ff6ffb89.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/page-996ae466a78a934e.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/app/play/page-d845373f86e18731.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/cb355538-ec6cdf481a292eea.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/e6909d18-5230cc3ec3f60e86.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/fd9d1056-a75d287af9d68cfc.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/framework-10c5a3a36623554f.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/main-97f8d15e45fabe94.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/main-app-5886811b5e274760.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/pages/HomePage-51d22054bb7358f4.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/pages/HomeTables-6a2076116883bbb4.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/pages/_app-9e9b8993d349c2ae.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/pages/_error-1be831200e60c5c0.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/chunks/polyfills-78c92fac7aa8fdd8.js",
+          revision: "79330112775102f91e1010318bae2bd3",
+        },
+        {
+          url: "/_next/static/chunks/webpack-34e15e5ec3c05453.js",
+          revision: "XxFJg-OXMBUYQ14-j1Lfd",
+        },
+        {
+          url: "/_next/static/css/b76e2b58b2186194.css",
+          revision: "b76e2b58b2186194",
+        },
+        {
+          url: "/blast-icon-color.svg",
+          revision: "f455c22475a343be9fcd764de7e7147e",
+        },
+        {
+          url: "/debug-icon.svg",
+          revision: "25aadc709736507034d14ca7aabcd29d",
+        },
+        {
+          url: "/debug-image.png",
+          revision: "34c4ca2676dd59ff24d6338faa1af371",
+        },
+        {
+          url: "/explorer-icon.svg",
+          revision: "84507da0e8989bb5b7616a3f66d31f48",
+        },
+        {
+          url: "/gradient-s.svg",
+          revision: "c003f595a6d30b1b476115f64476e2cf",
+        },
+        { url: "/logo.ico", revision: "3d10c9692073e77d925595322ae24c04" },
+        { url: "/logo.svg", revision: "13a19d77a1c682993b7c4fa9254a143a" },
+        { url: "/manifest.json", revision: "781788f3e2bc4b2b176b5d8c425d7475" },
+        { url: "/nft-art.png", revision: "14f53c64738877b3fa88aab9a910979b" },
+        { url: "/nft.png", revision: "d03c88ded58792ce4abda0659221ef4a" },
+        { url: "/poker.png", revision: "b9449effe384bcadd1ec623a59abfbe6" },
+        { url: "/poker.svg", revision: "9988ce4f9f7a583858e6331f21515d2c" },
+        {
+          url: "/pokerboots.svg",
+          revision: "9988ce4f9f7a583858e6331f21515d2c",
+        },
+        {
+          url: "/rpc-version.png",
+          revision: "cf97fd668cfa1221bec0210824978027",
+        },
+        {
+          url: "/scaffold-config.png",
+          revision: "1ebfc244c31732dc4273fe292bd07596",
+        },
+        {
+          url: "/sn-symbol-gradient.png",
+          revision: "908b60a4f6b92155b8ea38a009fa7081",
+        },
+        {
+          url: "/starkcompass-icon.svg",
+          revision: "eccc2ece017ee9e73e512996b74e49ac",
+        },
+        {
+          url: "/voyager-icon.svg",
+          revision: "06663dd5ba2c49423225a8e3893b45fe",
+        },
+      ],
+      { ignoreURLParametersMatching: [] },
+    ),
+    e.cleanupOutdatedCaches(),
+    e.registerRoute(
+      "/",
+      new e.NetworkFirst({
+        cacheName: "start-url",
+        plugins: [
+          {
+            cacheWillUpdate: async ({
+              request: e,
+              response: s,
+              event: n,
+              state: i,
+            }) =>
+              s && "opaqueredirect" === s.type
+                ? new Response(s.body, {
+                    status: 200,
+                    statusText: "OK",
+                    headers: s.headers,
+                  })
+                : s,
+          },
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
+      new e.CacheFirst({
+        cacheName: "google-fonts-webfonts",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 31536e3 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "google-fonts-stylesheets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 604800 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "static-font-assets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 4, maxAgeSeconds: 604800 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "static-image-assets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 64, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\/_next\/image\?url=.+$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "next-image",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 64, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:mp3|wav|ogg)$/i,
+      new e.CacheFirst({
+        cacheName: "static-audio-assets",
+        plugins: [
+          new e.RangeRequestsPlugin(),
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:mp4)$/i,
+      new e.CacheFirst({
+        cacheName: "static-video-assets",
+        plugins: [
+          new e.RangeRequestsPlugin(),
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:js)$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "static-js-assets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:css|less)$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "static-style-assets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\/_next\/data\/.+\/.+\.json$/i,
+      new e.StaleWhileRevalidate({
+        cacheName: "next-data",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      /\.(?:json|xml|csv)$/i,
+      new e.NetworkFirst({
+        cacheName: "static-data-assets",
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      ({ url: e }) => {
+        if (!(self.origin === e.origin)) return !1;
+        const s = e.pathname;
+        return !s.startsWith("/api/auth/") && !!s.startsWith("/api/");
+      },
+      new e.NetworkFirst({
+        cacheName: "apis",
+        networkTimeoutSeconds: 10,
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 16, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      ({ url: e }) => {
+        if (!(self.origin === e.origin)) return !1;
+        return !e.pathname.startsWith("/api/");
+      },
+      new e.NetworkFirst({
+        cacheName: "others",
+        networkTimeoutSeconds: 10,
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 86400 }),
+        ],
+      }),
+      "GET",
+    ),
+    e.registerRoute(
+      ({ url: e }) => !(self.origin === e.origin),
+      new e.NetworkFirst({
+        cacheName: "cross-origin",
+        networkTimeoutSeconds: 10,
+        plugins: [
+          new e.ExpirationPlugin({ maxEntries: 32, maxAgeSeconds: 3600 }),
+        ],
+      }),
+      "GET",
+    ));
+});


### PR DESCRIPTION
## Summary
- align connect and theme buttons with navbar links and make nav semi-transparent
- keep NFT cards fixed size and adjust grids for mobile
- compress tournaments table, add placeholders, and add load more button

## Testing
- `npm run lint`
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68923adcb8b88324bd90d1bcca064988