### PR TITLE
feat: render poker table with seat placeholders

### DIFF
--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -40,8 +40,8 @@ export default function PlayerSeat({
         </span>
       )}
 
-      {/* Pocket cards */}
-      <div className="flex gap-2">
+      {/* Pocket cards positioned above the seat */}
+      <div className="absolute -top-24 left-1/2 -translate-x-1/2 flex gap-2">
         <Card card={hole1} hidden={!revealCards} size="lg" />
         <Card card={hole2} hidden={!revealCards} size="lg" />
       </div>
@@ -63,3 +63,4 @@ export default function PlayerSeat({
     </div>
   );
 }
+

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -1,44 +1,101 @@
 // src/components/Table.tsx
 
 import { useGameStore } from "../hooks/useGameStore";
+import Card from "./Card";
+import PlayerSeat from "./PlayerSeat";
 
-/**
- * Basic table layout used by the play page.
- *
- * The previous version of this file accidentally re-imported itself which
- * resulted in an infinite recursion during the Next.js build process. This
- * lightweight component simply renders the current players and community
- * cards from the `useGameStore` state without any recursive imports.
- */
+/* ─── absolute positions (0 = top, 4 = bottom-center) ─── */
+const seatLayout = [
+  { x: "72%", y: "1%", t: "-50%,-50%" }, // 1 top-right
+  { x: "96%", y: "20%", t: "-50%,-50%" }, // 2 right-top
+  { x: "100%", y: "60%", t: "-50%,-50%" }, // 3 right
+  { x: "82%", y: "90%", t: "-50%,-50%" }, // 4 bottom-right
+  { x: "50%", y: "100%", t: "-50%,-100%" }, // 5 bottom (local)
+  { x: "18%", y: "90%", t: "-50%,-50%" }, // 6 bottom-left
+  { x: "0%", y: "60%", t: "-50%,-50%" }, // 7 left
+  { x: "4%", y: "20%", t: "-50%,-50%" }, // 8 left-top
+  { x: "28%", y: "1%", t: "-50%,-50%" }, // 9 top-left
+];
+
+/* ─────────────────────────────────────────────────────── */
+
 export default function Table() {
   const { players, community } = useGameStore();
 
-  return (
-    <section className="flex flex-col items-center gap-4">
-      {/* Community cards (shown as numeric placeholders for now) */}
-      <div className="flex gap-2">
-        {community.map((card, idx) => (
-          <span
-            key={idx}
-            className="w-12 h-16 rounded bg-green-700 flex items-center justify-center"
-          >
-            {card === null ? "?" : card}
-          </span>
-        ))}
-      </div>
+  /* helper – render a seat or an empty placeholder */
+  const seatAt = (idx: number) => {
+    const player = players[idx];
+    const style = {
+      left: seatLayout[idx].x,
+      top: seatLayout[idx].y,
+      transform: `translate(${seatLayout[idx].t})`,
+    } as React.CSSProperties;
 
-      {/* Player seats */}
-      <ul className="grid grid-cols-3 gap-2 text-sm">
-        {players.map((player, idx) => (
-          <li
-            key={idx}
-            className="px-2 py-1 rounded bg-green-800 text-center whitespace-nowrap"
-          >
-            {player ?? `Empty seat ${idx + 1}`}
-          </li>
-        ))}
-      </ul>
-    </section>
+    /* ── empty seat → button ─────────────────────────────── */
+    if (!player) {
+      return (
+        <button
+          key={idx}
+          style={style}
+          onClick={() => alert("Sit-down logic TBD")}
+          className="
+          absolute w-24 h-8 flex items-center justify-center rounded
+          text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20
+          transition-colors duration-150 hover:bg-red-500 hover:text-white
+        "
+        >
+          Join Seat
+        </button>
+      );
+    }
+
+    /* ── occupied seat ───────────────────────────────────── */
+    const isDealer = idx === 0;
+    const isActive = false; // turn logic TBD
+    const reveal = idx === 4; // local player
+
+    return (
+      <div key={idx} style={style} className="absolute">
+        <PlayerSeat
+          player={player}
+          isDealer={isDealer}
+          isActive={isActive}
+          revealCards={reveal}
+          bet={player.currentBet}
+        />
+      </div>
+    );
+  };
+
+  /* community cards – dead-centre via flexbox */
+  const communityRow = (
+    <div className="absolute inset-0 flex items-center justify-center gap-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Card
+          key={i}
+          card={community[i] ?? null}
+          hidden={i >= community.length}
+          size="md"
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="relative flex justify-center items-center py-24">
+      {/* poker-table oval */}
+      <div
+        className="
+          relative rounded-full border-8 border-[var(--brand-accent)] bg-gradient-to-br from-[#1e1e1e] to-[#0e0e0e]
+          shadow-[0_0_40px_rgba(0,0,0,0.6)]
+          w-[680px] h-[420px]
+        "
+      >
+        {communityRow}
+        {/* seats */}
+        {seatLayout.map((_, i) => seatAt(i))}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- style table as an oval poker surface with community cards centered
- show join buttons or active players around table edge
- place each player's hole cards above their seat on the table

## Testing
- `yarn next:lint`
- `yarn test:nextjs` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_68923cd3bf448324873ec2e1995015ae