### PR TITLE
fix card svg import and player typing

### DIFF
--- a/packages/nextjs/components/Card.tsx
+++ b/packages/nextjs/components/Card.tsx
@@ -1,4 +1,3 @@
-/// <reference types="vite/client" />
 // src/components/Card.tsx
 import Image from "next/image";
 import clsx from "clsx";
@@ -7,13 +6,21 @@ import cardStarknet from "../assets/svg-cards/card-starknet.svg";
 // import cardPokerBoots from '../assets/svg-cards/card-pokerboots.svg';
 
 /* ─────────── import all face SVGs at build-time ───────────
-   Vite’s eager glob returns an object whose values are the URLs
-   of the processed files (just like a normal `import ... from`).
+   Using Webpack's `require.context` so this works in a Next.js environment.
 */
-const faceSvgs = import.meta.glob("../assets/svg-cards/*_of_*.svg", {
-  eager: true,
-  import: "default",
-}) as Record<string, string>;
+function importAll(r: any) {
+  const images: Record<string, string> = {};
+  r.keys().forEach((key: string) => {
+    images[`../assets/svg-cards/${key.replace("./", "")}`] = r(key)
+      .default as string;
+  });
+  return images;
+}
+
+const faceSvgs = importAll(
+  // import all files matching "*_of_*.svg" in the svg-cards folder
+  (require as any).context("../assets/svg-cards", false, /_of_.*\.svg$/),
+);
 
 /* Helper: convert rank/suit symbols → filename stem */
 const rankMap: Record<string, string> = {

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -3,6 +3,7 @@
 import { useGameStore } from "../hooks/useGameStore";
 import Card from "./Card";
 import PlayerSeat from "./PlayerSeat";
+import type { Player } from "../game/types";
 
 /* ─── absolute positions (0 = top, 4 = bottom-center) ─── */
 const seatLayout = [
@@ -24,7 +25,7 @@ export default function Table() {
 
   /* helper – render a seat or an empty placeholder */
   const seatAt = (idx: number) => {
-    const player = players[idx];
+    const address = players[idx];
     const style = {
       left: seatLayout[idx].x,
       top: seatLayout[idx].y,
@@ -32,7 +33,7 @@ export default function Table() {
     } as React.CSSProperties;
 
     /* ── empty seat → button ─────────────────────────────── */
-    if (!player) {
+    if (!address) {
       return (
         <button
           key={idx}
@@ -50,6 +51,13 @@ export default function Table() {
     }
 
     /* ── occupied seat ───────────────────────────────────── */
+    const player: Player = {
+      name: address,
+      chips: 0,
+      hand: null,
+      folded: false,
+      currentBet: 0,
+    };
     const isDealer = idx === 0;
     const isActive = false; // turn logic TBD
     const reveal = idx === 4; // local player


### PR DESCRIPTION
## Summary
- handle card SVG imports in Next.js using Webpack `require.context`
- create placeholder Player objects from seat addresses

## Testing
- `yarn build`
- `yarn test:nextjs` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689243a0a3b08324ab86f25bf9991767