### PR TITLE
Fix community card type mismatch

### DIFF
--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -2,6 +2,7 @@
 
 import { useGameStore } from "../hooks/useGameStore";
 import Card from "./Card";
+import { indexToCard } from "../game/utils";
 import PlayerSeat from "./PlayerSeat";
 import type { Player } from "../game/types";
 
@@ -81,8 +82,10 @@ export default function Table() {
       {Array.from({ length: 5 }).map((_, i) => (
         <Card
           key={i}
-          card={community[i] ?? null}
-          hidden={i >= community.length}
+          card={
+            community[i] !== null ? indexToCard(community[i] as number) : null
+          }
+          hidden={community[i] === null}
           size="md"
         />
       ))}

--- a/packages/nextjs/game/utils.ts
+++ b/packages/nextjs/game/utils.ts
@@ -26,6 +26,13 @@ export function draw(deck: Card[]): Card {
   return card;
 }
 
+/** Convert a numeric card code (0..51) into a Card object */
+export function indexToCard(code: number): Card {
+  const rank = RANKS[code % RANKS.length];
+  const suit = SUITS[Math.floor(code / RANKS.length)];
+  return { rank, suit };
+}
+
 /* ─────────── Hand-ranking stub ───────────
    For production, wire in a proper evaluator like:
    npm i poker-evaluator


### PR DESCRIPTION
## Summary
- decode numeric card codes into `Card` objects
- render community cards using decoded `Card` instances

## Testing
- `yarn workspace @ss-2/nextjs lint`
- `yarn workspace @ss-2/nextjs test`
- `yarn workspace @ss-2/nextjs build` *(fails: ENETUNREACH while patching lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6892871c6a588324811580f99ffc92a6