### PR TITLE
feat: improve nft responsiveness

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import HeroSection from "../components/HeroSection";
-import MostPopularSection from "../components/MostPopularSection";
+import TrendingSection from "../components/TrendingSection";
 import TournamentsTableSection from "../components/TournamentsTableSection";
 import MarketplaceSection from "../components/MarketplaceSection";
 import StayTunedSection from "../components/StayTunedSection";
@@ -11,7 +11,7 @@ export default function HomePage() {
   return (
     <main className="flex flex-col items-stretch">
       <HeroSection />
-      <MostPopularSection />
+      <TrendingSection />
       <TournamentsTableSection />
       <StayTunedSection />
     </main>

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -4,9 +4,21 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 
 const slides = [
-  { id: 0, title: "Next-gen poker lives on-Starknet", image: "/carousel/pokernfts1.png" },
-  { id: 1, title: "Fair play isn't optional — it's built in.", image: "/carousel/pokernfts2.png" },
-  { id: 2, title: "Every Hand Verified. Every Bet on Chain.", image: "/carousel/pokernfts3.png" },
+  {
+    id: 0,
+    title: "Next-gen poker lives on-Starknet",
+    image: "/carousel/pokernfts1.png",
+  },
+  {
+    id: 1,
+    title: "Fair play isn't optional — it's built in.",
+    image: "/carousel/pokernfts2.png",
+  },
+  {
+    id: 2,
+    title: "Every Hand Verified. Every Bet on Chain.",
+    image: "/carousel/pokernfts3.png",
+  },
   { id: 3, title: "Permissionless wins.", image: "/carousel/pokernfts4.png" },
 ];
 

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -63,4 +63,3 @@ export default function PlayerSeat({
     </div>
   );
 }
-

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -134,7 +134,6 @@ const columns: { key: SortKey; label: string; numeric?: boolean }[] = [
   { key: "sold", label: "Sold", numeric: true },
   { key: "prizes", label: "Prizes" },
   { key: "date", label: "Date" },
-  { key: "supply", label: "Supply", numeric: true },
 ];
 
 export default function TournamentsTableSection() {
@@ -178,7 +177,10 @@ export default function TournamentsTableSection() {
             <thead className="bg-gray-900 text-gray-400 uppercase text-[10px] sm:text-xs">
               <tr>
                 {columns.map((col) => (
-                  <th key={col.key} className="px-2 py-2 text-left relative">
+                  <th
+                    key={col.key}
+                    className={`px-2 py-1 relative ${col.numeric ? "text-center" : "text-left"}`}
+                  >
                     <button
                       className="flex items-center gap-1"
                       onClick={() => toggleColumn(col.key)}
@@ -208,28 +210,29 @@ export default function TournamentsTableSection() {
             <tbody className="bg-black divide-y divide-gray-800">
               {sorted.map((t) => (
                 <tr key={t.id} className="hover:bg-gray-900 transition">
-                  <td className="px-2 py-2">
+                  <td className="px-2 py-1">
                     <img
                       src={t.nft}
                       alt={t.name}
                       className="w-12 h-12 object-cover rounded"
                     />
                   </td>
-                  <td className="px-2 py-2">{t.name}</td>
-                  <td className="px-2 py-2 flex items-center gap-2">
+                  <td className="px-2 py-1">{t.name}</td>
+                  <td className="px-2 py-1 flex items-center gap-2">
                     <img
                       src={t.creatorAvatar}
                       alt={t.creator}
-                      className="w-6 h-6 rounded-full"
+                      className="w-6 h-6 rounded-full object-cover"
                     />
                     <span>{t.creator}</span>
                   </td>
-                  <td className="px-2 py-2">{t.game}</td>
-                  <td className="px-2 py-2 text-green-400">{t.buyIn}</td>
-                  <td className="px-2 py-2 text-orange-400">{t.sold}</td>
-                  <td className="px-2 py-2">{t.prizes}</td>
-                  <td className="px-2 py-2">{t.date}</td>
-                  <td className="px-2 py-2">{t.supply}</td>
+                  <td className="px-2 py-1">{t.game}</td>
+                  <td className="px-2 py-1 text-green-400 text-center">
+                    {t.buyIn}
+                  </td>
+                  <td className="px-2 py-1 text-orange-400 text-center">{`${t.sold}/${t.supply}`}</td>
+                  <td className="px-2 py-1">{t.prizes}</td>
+                  <td className="px-2 py-1">{t.date}</td>
                 </tr>
               ))}
             </tbody>

--- a/packages/nextjs/components/TrendingSection.tsx
+++ b/packages/nextjs/components/TrendingSection.tsx
@@ -2,7 +2,7 @@ import { PopularNftCard, type PopularNftCardProps } from "./ui/PopularNftCard";
 
 type PopularNftItem = PopularNftCardProps & { id: number };
 
-const items: PopularNftItem[] = Array.from({ length: 5 }).map((_, i) => ({
+const items: PopularNftItem[] = Array.from({ length: 14 }).map((_, i) => ({
   id: i,
   title: `PUNK${1000 + i}`,
   image: "/nft.png",
@@ -17,18 +17,20 @@ const items: PopularNftItem[] = Array.from({ length: 5 }).map((_, i) => ({
 }));
 
 /**
- * Grid of popular NFTs similar to Rarible's latest drops.
+ * Horizontally scrollable grid of trending NFTs.
  */
-export default function MostPopularSection() {
+export default function TrendingSection() {
   return (
     <section className="py-12 px-4 sm:px-6 md:px-12">
       <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
-        Most Popular
+        Trending
       </h2>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 md:gap-6 justify-items-center">
-        {items.map((item) => (
-          <PopularNftCard key={item.id} {...item} />
-        ))}
+      <div className="overflow-x-auto pb-2">
+        <div className="grid grid-cols-7 gap-4 md:gap-6 w-max">
+          {items.map((item) => (
+            <PopularNftCard key={item.id} {...item} />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/packages/nextjs/components/ui/NFTCard.tsx
+++ b/packages/nextjs/components/ui/NFTCard.tsx
@@ -23,8 +23,8 @@ export const NFTCard: React.FC<NFTCardProps> = ({
   badge,
   actionLabel = "Buy now",
 }) => (
-  <div className="group relative w-48 sm:w-56 flex-shrink-0">
-    <div className="relative w-48 h-48 sm:w-56 sm:h-56 overflow-hidden rounded-lg bg-base-300">
+  <div className="group relative w-48 sm:w-56 flex-shrink-0 min-w-[10rem]">
+    <div className="relative w-full aspect-square overflow-hidden rounded-lg bg-base-300">
       <Image
         src={image}
         alt={title}

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -26,15 +26,9 @@ export const PopularNftCard: FC<PopularNftCardProps> = ({
   maxRegistered,
   prize,
 }) => (
-  <div className="w-48 sm:w-64 bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
-    <div className="relative w-48 h-48 sm:w-64 sm:h-64 overflow-hidden">
-      <Image
-        src={image}
-        alt={title}
-        width={256}
-        height={256}
-        className="w-full h-full object-cover"
-      />
+  <div className="w-40 sm:w-48 md:w-64 min-w-[10rem] bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
+    <div className="relative w-full aspect-square overflow-hidden">
+      <Image src={image} alt={title} fill className="object-cover" />
     </div>
     <div className="px-2 pb-2 space-y-1" />
     <div className="px-2 flex justify-between text-xs text-gray-600 font-medium">


### PR DESCRIPTION
## Summary
- make trending section responsive with two scrollable rows
- refine nft cards and table layout for better fit

## Testing
- `yarn next:lint`
- `yarn test:nextjs`

------
https://chatgpt.com/codex/tasks/task_e_689286e0ae788324ab623ea166c1883e