### PR TITLE
feat: refresh theme with dark default

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -13,7 +13,7 @@ const ScaffoldStarkApp = ({ children }: { children: React.ReactNode }) => {
   return (
     <html suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <ThemeProvider enableSystem>
+        <ThemeProvider>
           <ScaffoldStarkAppWithProviders>
             {children}
           </ScaffoldStarkAppWithProviders>

--- a/packages/nextjs/components/ThemeProvider.tsx
+++ b/packages/nextjs/components/ThemeProvider.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ThemeProviderProps } from "next-themes/dist/types";
 
-export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
-};
+export const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => (
+  <NextThemesProvider attribute="class" defaultTheme="dark" {...props}>
+    {children}
+  </NextThemesProvider>
+);

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -4,8 +4,8 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap");
 
 :root {
-  --color-primary: #141416;
-  --color-accent: #3772ff;
+  --color-primary: #0d1117;
+  --color-accent: #38bdf8;
   --color-background: #f9fafb;
   --color-border: #e5e7eb;
 }
@@ -67,7 +67,7 @@ body {
 
 .circle-gradient {
   border-radius: 630px;
-  background: #bd93f1;
+  background: #93c5fd;
   filter: blur(229px);
   position: absolute;
   top: 0;
@@ -75,7 +75,7 @@ body {
 
 .circle-gradient-blue {
   border-radius: 630px;
-  background: #a6e8fe;
+  background: #d8b4fe;
   filter: blur(250px);
   position: absolute;
   top: 0;
@@ -83,7 +83,7 @@ body {
 }
 
 .border-gradient {
-  border: 1px solid #5c4fe5;
+  border: 1px solid #7c3aed;
 }
 
 .bg-modal {
@@ -117,8 +117,8 @@ body {
     width: 1rem;
     height: 1rem;
     background: inherit;
-    border-top: 1px solid #8a45fc;
-    border-right: 1px solid #8a45fc;
+    border-top: 1px solid #7c3aed;
+    border-right: 1px solid #7c3aed;
     clip-path: polygon(100% 0, 0 0, 100% 100%);
     z-index: 10;
   }
@@ -129,13 +129,13 @@ body {
   top: 0;
   left: 60px;
   border-radius: 630px;
-  background: #7353d2;
+  background: #7c3aed;
   filter: blur(229px);
 }
 
 .circle-gradient-blue-dark {
   border-radius: 630px;
-  background: #0ea9ff;
+  background: #38bdf8;
   filter: blur(250px);
   position: absolute;
   top: 0;
@@ -148,7 +148,7 @@ body {
     height: 6px;
     clip-path: polygon(10% 100%, 90% 100%, 100% 0, 0 0);
     position: relative;
-    background-color: #5c4fe5;
+    background-color: #7c3aed;
     position: absolute;
     top: -1px;
   }

--- a/packages/nextjs/tailwind.config.ts
+++ b/packages/nextjs/tailwind.config.ts
@@ -1,124 +1,83 @@
 import type { Config } from "tailwindcss";
+import daisyui from "daisyui";
 
 const config: Config = {
-  content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
-  daisyui: {
-    themes: [
-      {
-        mytheme: {
-          primary: "#794BFC",
-
-          secondary: "F4F1FD",
-
-          accent: "#ff00ff",
-
-          neutral: "#ff00ff",
-
-          "base-100": "#ffffff",
-
-          info: "#0000ff",
-
-          success: "#00ffff",
-
-          warning: "#00ff00",
-
-          error: "#ff0000",
-        },
-      },
-    ],
-  },
-  theme: {
-    extend: {
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-      },
-    },
-  },
-  plugins: [require("daisyui")],
-};
-export default config;
-/** @type {import('tailwindcss').Config} */
-module.exports = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
     "./utils/**/*.{js,ts,jsx,tsx}",
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  plugins: [require("daisyui")],
   darkTheme: "dark",
-  // DaisyUI theme colors
   daisyui: {
     themes: [
       {
         light: {
-          primary: "#93BBFB",
-          "primary-content": "#2A3655",
-          secondary: "#8B45FD",
-          "secondary-content": "#7800FF",
-          accent: "#93BBFB",
-          "accent-content": "#212638",
-          neutral: "#212638",
-          "neutral-content": "#ffffff",
-          "base-100": "#ffffff",
-          "base-200": "#f4f8ff",
-          "base-300": "#ffffff",
-          "base-content": "#212638",
-          info: "#93BBFB",
-          success: "#34EEB6",
-          warning: "#FFCF72",
-          error: "#FF8863",
+          primary: "#3B82F6",
+          "primary-content": "#FFFFFF",
+          secondary: "#7C3AED",
+          "secondary-content": "#FFFFFF",
+          accent: "#38BDF8",
+          "accent-content": "#1F2937",
+          neutral: "#1F2937",
+          "neutral-content": "#FFFFFF",
+          "base-100": "#FFFFFF",
+          "base-200": "#F3F4F6",
+          "base-300": "#E5E7EB",
+          "base-content": "#1F2937",
+          info: "#3B82F6",
+          success: "#10B981",
+          warning: "#FBBF24",
+          error: "#EF4444",
           ".bg-gradient-modal": {
             "background-image":
-              "linear-gradient(270deg, #A7ECFF -17.42%, #E8B6FF 109.05%)",
+              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
           },
           ".bg-modal": {
             background:
-              "linear-gradient(270deg, #ece9fb -17.42%, #e3f4fd 109.05%)",
+              "linear-gradient(270deg,#F3F4F6 -17.42%, #E0E7FF 109.05%)",
           },
           ".modal-border": {
-            border: "1px solid #5c4fe5",
+            border: "1px solid #7C3AED",
           },
           ".bg-gradient-nav": {
-            background: "#000000",
+            background:
+              "linear-gradient(90deg,#3B82F6 0%, #7C3AED 100%)",
           },
           ".bg-main": {
-            background: "#FFFFFF",
+            background:
+              "radial-gradient(at 50% 0%, rgba(147,197,253,0.4), rgba(216,180,254,0.2) 60%), #FFFFFF",
           },
           ".bg-underline": {
             background:
-              "linear-gradient(270deg, #A7ECFF -17.42%, #E8B6FF 109.05%)",
+              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
           },
           ".bg-container": {
             background: "transparent",
           },
           ".bg-btn-wallet": {
             "background-image":
-              "linear-gradient(270deg, #A7ECFF -17.42%, #E8B6FF 109.05%)",
+              "linear-gradient(90deg,#3B82F6 0%, #7C3AED 100%)",
           },
           ".bg-input": {
-            background: "rgba(0, 0, 0, 0.07)",
+            background: "rgba(0, 0, 0, 0.05)",
           },
           ".bg-component": {
-            background: "rgba(255, 255, 255, 0.55)",
+            background: "rgba(255, 255, 255, 0.65)",
           },
           ".bg-function": {
             background:
-              "linear-gradient(270deg, #A7ECFF -17.42%, #E8B6FF 109.05%)",
+              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
           },
           ".text-function": {
-            color: "#3C1DFF",
+            color: "#7C3AED",
           },
           ".text-network": {
-            color: "#7800FF",
+            color: "#3B82F6",
           },
           "--rounded-btn": "9999rem",
-
           ".tooltip": {
             "--tooltip-tail": "6px",
           },
@@ -135,67 +94,67 @@ module.exports = {
       },
       {
         dark: {
-          primary: "#212638",
-          "primary-content": "#DAE8FF",
-          secondary: "#8b45fd",
-          "secondary-content": "#0FF",
-          accent: "#4969A6",
-          "accent-content": "#F9FBFF",
-          neutral: "#F9FBFF",
-          "neutral-content": "#385183",
-          "base-100": "#1C223B",
-          "base-200": "#2A3655",
-          "base-300": "#141a30",
-          "base-content": "#F9FBFF",
-          info: "#385183",
-          success: "#34EEB6",
-          warning: "#FFCF72",
-          error: "#FF8863",
+          primary: "#0D1117",
+          "primary-content": "#E2E8F0",
+          secondary: "#7C3AED",
+          "secondary-content": "#C4B5FD",
+          accent: "#38BDF8",
+          "accent-content": "#0F172A",
+          neutral: "#F9FAFB",
+          "neutral-content": "#0F172A",
+          "base-100": "#0D1117",
+          "base-200": "#1B1E32",
+          "base-300": "#111827",
+          "base-content": "#F9FAFB",
+          info: "#38BDF8",
+          success: "#10B981",
+          warning: "#FBBF24",
+          error: "#F87171",
           ".bg-gradient-modal": {
-            background: "#385183",
+            background: "#1E3A8A",
           },
           ".bg-modal": {
-            background: "linear-gradient(90deg, #2B2243 0%, #253751 100%)",
+            background:
+              "linear-gradient(90deg,#1E1B4B 0%, #1B2838 100%)",
           },
           ".modal-border": {
-            border: "1px solid #4f4ab7",
+            border: "1px solid #4B5563",
           },
           ".bg-gradient-nav": {
             "background-image":
-              "var(--gradient, linear-gradient(90deg, #42D2F1 0%, #B248DD 100%))",
+              "linear-gradient(90deg,#38BDF8 0%, #7C3AED 100%)",
           },
           ".bg-main": {
-            background: "#141A31",
+            background:
+              "radial-gradient(at 50% 0%, rgba(56,189,248,0.25), rgba(124,58,237,0.15) 60%), #0D1117",
           },
           ".bg-underline": {
-            background: "#5368B4",
+            background: "#374151",
           },
           ".bg-container": {
-            background: "#141a30",
+            background: "#1B1E32",
           },
           ".bg-btn-wallet": {
             "background-image":
-              "linear-gradient(180deg, #3457D1 0%, #8A45FC 100%)",
+              "linear-gradient(180deg,#3B82F6 0%, #7C3AED 100%)",
           },
           ".bg-input": {
             background: "rgba(255, 255, 255, 0.07)",
           },
           ".bg-component": {
             background:
-              "linear-gradient(113deg,rgba(43, 34, 67, 0.6) 20.48%,rgba(37, 55, 81, 0.6) 99.67%)",
+              "linear-gradient(113deg,rgba(30,27,75,0.6) 20.48%,rgba(27,40,56,0.6) 99.67%)",
           },
           ".bg-function": {
-            background: "rgba(139, 69, 253, 0.37)",
+            background: "rgba(124,58,237,0.37)",
           },
           ".text-function": {
-            color: "#1DD6FF",
+            color: "#38BDF8",
           },
           ".text-network": {
-            color: "#D0A6FF",
+            color: "#D8B4FE",
           },
-
           "--rounded-btn": "9999rem",
-
           ".tooltip": {
             "--tooltip-tail": "6px",
             "--tooltip-color": "oklch(var(--p))",
@@ -208,7 +167,7 @@ module.exports = {
           },
           ".contract-content": {
             background:
-              "linear-gradient(113.34deg, rgba(43, 34, 67, 0.6) 20.48%, rgba(37, 55, 81, 0.6) 99.67%)",
+              "linear-gradient(113.34deg, rgba(30,27,75,0.6) 20.48%, rgba(27,40,56,0.6) 99.67%)",
           },
         },
       },
@@ -224,17 +183,17 @@ module.exports = {
       },
       backgroundImage: {
         "gradient-light":
-          "linear-gradient(270deg, #A7ECFF -17.42%, #E8B6FF 109.05%)",
+          "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
         "gradient-dark":
-          "var(--gradient, linear-gradient(90deg, #42D2F1 0%, #B248DD 100%))",
+          "linear-gradient(90deg,#38BDF8 0%, #7C3AED 100%)",
         "gradient-vertical":
-          "linear-gradient(180deg, #3457D1 0%, #8A45FC 100%)",
+          "linear-gradient(180deg,#3B82F6 0%, #7C3AED 100%)",
         "gradient-icon":
-          "var(--gradient, linear-gradient(90deg, #42D2F1 0%, #B248DD 100%))",
+          "linear-gradient(90deg,#38BDF8 0%, #7C3AED 100%)",
       },
       colors: {
-        primary: "#141416",
-        accent: "#3772FF",
+        primary: "#0D1117",
+        accent: "#38BDF8",
         background: "#F9FAFB",
         border: "#E5E7EB",
       },
@@ -243,4 +202,7 @@ module.exports = {
       },
     },
   },
+  plugins: [daisyui],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- set dark mode as default theme and unify theme provider
- overhaul light/dark palettes with night-inspired radial backgrounds
- update global styles for new color system and specular effects

## Testing
- `yarn next:lint`
- `yarn next:check-types`
- `yarn test:nextjs`

------
https://chatgpt.com/codex/tasks/task_e_68929a86778483249791ddbdc48154e5