### PR TITLE
Add how-it-works timeline and theme updates

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import HeroSection from "../components/HeroSection";
+import HowItWorksSection from "../components/HowItWorksSection";
 import TrendingSection from "../components/TrendingSection";
 import TournamentsTableSection from "../components/TournamentsTableSection";
 import MarketplaceSection from "../components/MarketplaceSection";
@@ -11,8 +12,10 @@ export default function HomePage() {
   return (
     <main className="flex flex-col items-stretch">
       <HeroSection />
+      <HowItWorksSection />
       <TrendingSection />
       <TournamentsTableSection />
+      <MarketplaceSection />
       <StayTunedSection />
     </main>
   );

--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import ActionBar from "../../components/ActionBar";
 import Table from "../../components/Table";
 import { useGameStore } from "../../hooks/useGameStore";
@@ -9,10 +9,6 @@ export default function PlayPage() {
   const { street, reloadTableState, startHand, dealFlop, dealTurn, dealRiver } =
     useGameStore();
 
-  const [isJoining, setIsJoining] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const TOURNAMENT_ID = "1";
-
   useEffect(() => {
     async function connect() {
       if (window.starknet) {
@@ -20,34 +16,29 @@ export default function PlayPage() {
           await window.starknet.enable({ showModal: true });
           await reloadTableState();
         } catch {
-          setError("Wallet connection failed");
+          console.error("Wallet connection failed");
         }
       } else {
-        setError("No Starknet wallet found");
+        console.error("No Starknet wallet found");
       }
     }
     connect();
   }, [reloadTableState]);
 
-  async function handleJoinTable() {
-    setError(null);
-    setIsJoining(true);
-  }
+  const stageNames = ["preflop", "flop", "turn", "river", "showdown"] as const;
 
   return (
-    <main className="min-h-screen flex flex-col items-center bg-gradient-to-br from-green-900 to-green-700 text-white">
+    <main className="min-h-screen flex flex-col items-center bg-gradient-to-br from-[#0d0d0d] via-[#1b1b1b] to-[#232323] text-white">
       <header className="relative w-full max-w-6xl flex items-center justify-between mt-6 mb-4 px-4">
-        <h1 className="text-4xl font-bold">Tournament Table</h1>
+        <h1 className="text-4xl font-bold">PokerBoots × Starknet</h1>
         <button
-          disabled={isJoining}
-          className="absolute left-1/2 -translate-x-1/2 px-4 py-2 rounded bg-blue-900 hover:bg-red-500 font-semibold disabled:opacity-50"
-          onClick={handleJoinTable}
+          className="absolute left-1/2 -translate-x-1/2 btn"
+          onClick={() => alert("join logic TBD")}
         >
-          {isJoining ? "Joining…" : "Join Table"}
+          Join Table
         </button>
-        {error && <p className="text-red-400 ml-2">{error}</p>}
         <ActionBar
-          street={street}
+          street={stageNames[street] ?? "preflop"}
           onStart={startHand}
           onFlop={dealFlop}
           onTurn={dealTurn}

--- a/packages/nextjs/components/ActionBar.tsx
+++ b/packages/nextjs/components/ActionBar.tsx
@@ -1,44 +1,33 @@
 // src/components/ActionBar.tsx
 interface Props {
-  street: number;
-  onStart: () => void;
-  onFlop: () => void;
-  onTurn: () => void;
-  onRiver: () => void;
+  street: string;
+  onStart(): void;
+  onFlop(): void;
+  onTurn(): void;
+  onRiver(): void;
 }
 
-export default function ActionBar({
-  street,
-  onStart,
-  onFlop,
-  onTurn,
-  onRiver,
-}: Props) {
+export default function ActionBar({ street, ...actions }: Props) {
   return (
-    <div className="flex gap-4">
-      {street === 0 && (
-        <button onClick={onStart} className="btn">
-          Deal Hole Cards
-        </button>
-      )}
-      {street === 1 && (
-        <button onClick={onFlop} className="btn">
+    <div className="flex gap-4 card p-2 rounded-full">
+      {street === "preflop" && (
+        <button onClick={actions.onFlop} className="btn">
           Deal Flop
         </button>
       )}
-      {street === 2 && (
-        <button onClick={onTurn} className="btn">
+      {street === "flop" && (
+        <button onClick={actions.onTurn} className="btn">
           Deal Turn
         </button>
       )}
-      {street === 3 && (
-        <button onClick={onRiver} className="btn">
+      {street === "turn" && (
+        <button onClick={actions.onRiver} className="btn">
           Deal River
         </button>
       )}
-      {street >= 4 && (
-        <button disabled className="btn opacity-50">
-          Showdown Done
+      {street === "river" && (
+        <button onClick={actions.onStart} className="btn">
+          New Hand
         </button>
       )}
     </div>

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -23,7 +23,7 @@ type HeaderMenuLink = {
 export const menuLinks: HeaderMenuLink[] = [
   { label: "Home", href: "/#home" },
   { label: "How it Works", href: "/#how" },
-  { label: "Top Tournaments", href: "/#tournaments" },
+  { label: "Trending", href: "/#tournaments" },
   { label: "Marketplace", href: "/#marketplace" },
 ];
 

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -40,7 +40,10 @@ export default function HeroSection() {
   const prev = () => setIndex((index - 1 + slides.length) % slides.length);
 
   return (
-    <section className="relative h-[60vh] md:h-[70vh] overflow-hidden">
+    <section
+      id="home"
+      className="relative h-[60vh] md:h-[70vh] overflow-hidden"
+    >
       {slides.map((s, i) => (
         <div
           key={s.id}

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const steps = [
+  "Connect your wallet",
+  "Join a table",
+  "Get your cards",
+  "Play the rounds",
+  "Win the pot",
+];
+
+export default function HowItWorksSection() {
+  return (
+    <section
+      id="how"
+      className="py-12 px-4 sm:px-6 md:px-12 bg-white text-gray-900 dark:bg-gray-900 dark:text-white flex flex-col md:flex-row items-center gap-8"
+    >
+      <div className="w-full md:w-1/2">
+        <video
+          controls
+          className="w-full rounded-lg shadow-lg"
+          src="https://www.w3schools.com/html/mov_bbb.mp4"
+        />
+      </div>
+      <div className="w-full md:w-1/2">
+        <h2 className="text-3xl md:text-4xl font-bold mb-6">How It Works</h2>
+        <div className="relative">
+          <div className="absolute top-4 left-0 right-0 h-0.5 bg-gray-300 dark:bg-gray-700" />
+          <div className="flex justify-between relative">
+            {steps.map((step, idx) => (
+              <div
+                key={idx}
+                className="flex flex-col items-center text-center w-1/5"
+              >
+                <div className="w-8 h-8 rounded-full bg-[#8a45fc] text-white flex items-center justify-center z-10">
+                  {idx + 1}
+                </div>
+                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                  {step}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/nextjs/components/MarketplaceSection.tsx
+++ b/packages/nextjs/components/MarketplaceSection.tsx
@@ -13,7 +13,10 @@ const items = Array.from({ length: 8 }).map((_, i) => ({
 
 export default function MarketplaceSection() {
   return (
-    <section className="py-12 px-4 sm:px-6">
+    <section
+      id="marketplace"
+      className="py-12 px-4 sm:px-6 bg-white dark:bg-gray-900"
+    >
       <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-6">
         <div className="md:col-span-3 mb-6 md:mb-0">
           <FiltersSidebar />

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -167,14 +167,17 @@ export default function TournamentsTableSection() {
   };
 
   return (
-    <section className="text-white p-4 sm:p-8">
+    <section
+      id="tournaments"
+      className="p-4 sm:p-8 bg-white text-gray-900 dark:bg-black dark:text-white"
+    >
       <div className="max-w-6xl mx-auto">
         <h2 className="text-3xl font-bold mb-6">
           Trending <span className="text-yellow-400">Top</span>
         </h2>
-        <div className="overflow-auto rounded-lg border border-gray-700">
+        <div className="overflow-auto rounded-lg border border-gray-300 dark:border-gray-700">
           <table className="min-w-full text-xs sm:text-sm table-auto">
-            <thead className="bg-gray-900 text-gray-400 uppercase text-[10px] sm:text-xs">
+            <thead className="bg-gray-100 text-gray-600 dark:bg-gray-900 dark:text-gray-400 uppercase text-[10px] sm:text-xs">
               <tr>
                 {columns.map((col) => (
                   <th
@@ -207,9 +210,9 @@ export default function TournamentsTableSection() {
                 ))}
               </tr>
             </thead>
-            <tbody className="bg-black divide-y divide-gray-800">
+            <tbody className="bg-white dark:bg-black divide-y divide-gray-200 dark:divide-gray-800">
               {sorted.map((t) => (
-                <tr key={t.id} className="hover:bg-gray-900 transition">
+                <tr key={t.id} className="hover:bg-gray-50 dark:hover:bg-gray-900 transition">
                   <td className="px-2 py-1">
                     <img
                       src={t.nft}
@@ -227,10 +230,10 @@ export default function TournamentsTableSection() {
                     <span>{t.creator}</span>
                   </td>
                   <td className="px-2 py-1">{t.game}</td>
-                  <td className="px-2 py-1 text-green-400 text-center">
+                  <td className="px-2 py-1 text-green-600 dark:text-green-400 text-center">
                     {t.buyIn}
                   </td>
-                  <td className="px-2 py-1 text-orange-400 text-center">{`${t.sold}/${t.supply}`}</td>
+                  <td className="px-2 py-1 text-orange-600 dark:text-orange-400 text-center">{`${t.sold}/${t.supply}`}</td>
                   <td className="px-2 py-1">{t.prizes}</td>
                   <td className="px-2 py-1">{t.date}</td>
                 </tr>

--- a/packages/nextjs/components/TrendingSection.tsx
+++ b/packages/nextjs/components/TrendingSection.tsx
@@ -21,7 +21,10 @@ const items: PopularNftItem[] = Array.from({ length: 14 }).map((_, i) => ({
  */
 export default function TrendingSection() {
   return (
-    <section className="py-12 px-4 sm:px-6 md:px-12">
+    <section
+      id="trending"
+      className="py-12 px-4 sm:px-6 md:px-12 bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
+    >
       <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
         Trending
       </h2>


### PR DESCRIPTION
## Summary
- add video-based how-it-works section and link from header
- wire header anchors and improve light/dark theming across sections
- restyle play table action flow and update navigation labels

## Testing
- `yarn test:nextjs`

------
https://chatgpt.com/codex/tasks/task_e_6892c8b28654832497e677b2b545be28