### PR TITLE
Refine hero, mission marquee and add NFT buy stubs

### DIFF
--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -60,18 +60,16 @@ export default function HeroSection() {
 
       <div className="absolute inset-0 bg-black/40" />
 
-      <div className="relative z-10 h-full flex flex-col justify-center items-start px-6 md:px-12">
-        <h1 className="text-3xl md:text-5xl font-bold mb-4">
+      <div className="relative z-10 h-full flex flex-col justify-center items-center text-center px-6 md:px-12">
+        <h1 className="text-3xl md:text-5xl font-bold mb-6">
           {slides[index].title}
         </h1>
-        <div className="flex gap-4">
-          <a
-            href="/play"
-            className="px-6 py-3 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow hover:bg-yellow-300 transition-colors"
-          >
-            Play
-          </a>
-        </div>
+        <a
+          href="/play"
+          className="px-8 py-4 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_#facc15] animate-pulse hover:shadow-[0_0_20px_#facc15]"
+        >
+          Play
+        </a>
       </div>
 
       <button

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -13,42 +13,67 @@ export default function HowItWorksSection() {
     <section className="bg-black text-white py-16 px-4">
       <div className="max-w-6xl mx-auto">
         <h2 className="text-3xl sm:text-4xl font-bold text-center mb-12">
-          Create Your Own <span className="text-yellow-400">POKER</span> Tournament
+          Create Your Own <span className="text-yellow-400">POKER</span>{" "}
+          Tournament
         </h2>
 
         <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
             <h3 className="text-xl font-semibold mb-2">🎨 Create an NFT</h3>
-            <p>Upload your own artwork. This NFT will represent your tournament entry ticket.</p>
+            <p>
+              Upload your own artwork. This NFT will represent your tournament
+              entry ticket.
+            </p>
           </div>
 
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
-            <h3 className="text-xl font-semibold mb-2">💰 Set Price, Supply & Date</h3>
-            <p>Choose your buy-in price, total supply, and tournament start date.</p>
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
+            <h3 className="text-xl font-semibold mb-2">
+              💰 Set Price, Supply & Date
+            </h3>
+            <p>
+              Choose your buy-in price, total supply, and tournament start date.
+            </p>
           </div>
 
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
-            <h3 className="text-xl font-semibold mb-2">🛒 Bring Your Followers</h3>
-            <p>Share and sell your NFT to your community. Each buyer gets a seat at the table!</p>
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
+            <h3 className="text-xl font-semibold mb-2">
+              🛒 Bring Your Followers
+            </h3>
+            <p>
+              Share and sell your NFT to your community. Each buyer gets a seat
+              at the table!
+            </p>
           </div>
 
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
-            <h3 className="text-xl font-semibold mb-2">♠️ Protocol Spins Up a Table</h3>
-            <p>Once funded, the protocol automatically launches a secure onchain poker game.</p>
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
+            <h3 className="text-xl font-semibold mb-2">
+              ♠️ Protocol Spins Up a Table
+            </h3>
+            <p>
+              Once funded, the protocol automatically launches a secure onchain
+              poker game.
+            </p>
           </div>
 
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
             <h3 className="text-xl font-semibold mb-2">📈 Fund Distribution</h3>
-            <p>Funds split: <span className="text-yellow-400">80%</span> prizes, <span className="text-blue-400">10%</span> creator, <span className="text-pink-400">10%</span> protocol.</p>
+            <p>
+              Funds split: <span className="text-yellow-400">80%</span> prizes,{" "}
+              <span className="text-blue-400">10%</span> creator,{" "}
+              <span className="text-pink-400">10%</span> protocol.
+            </p>
           </div>
 
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg">
-            <h3 className="text-xl font-semibold mb-2">🏆 Win Prizes & $POKER Airdrop</h3>
-            <p>Top 15% win prize money and get a bonus airdrop of $POKER tokens.</p>
+          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
+            <h3 className="text-xl font-semibold mb-2">
+              🏆 Win Prizes & $POKER Airdrop
+            </h3>
+            <p>
+              Top 15% win prize money and get a bonus airdrop of $POKER tokens.
+            </p>
           </div>
         </div>
       </div>
     </section>
-
   );
 }

--- a/packages/nextjs/components/MissionStatementSection.tsx
+++ b/packages/nextjs/components/MissionStatementSection.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 
-const steps = [
-  "Connect your wallet",
-  "Join a table",
-  "Get your cards",
-  "Play the rounds",
-  "Win the pot",
-];
+const message =
+  "Solving fraud in online poker, much like Bitcoin solved fraud in banking!";
 
-export default function HowItWorksSection() {
+export default function MissionStatementSection() {
   return (
-    <section className="bg-black text-white py-16 px-4">
-      <div className="max-w-6xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-center mb-12">
-          <span className="text-yellow-400">Solving fraud in online poker, much like Bitcoin solved fraud in banking!</span>
-        </h2>
+    <section className="bg-black text-white py-4 overflow-hidden">
+      <div className="whitespace-nowrap">
+        <div className="animate-marquee inline-block">
+          <span className="mx-8">{message}</span>
+          <span className="mx-8">{message}</span>
+        </div>
       </div>
     </section>
-
   );
 }

--- a/packages/nextjs/components/StayTunedSection.tsx
+++ b/packages/nextjs/components/StayTunedSection.tsx
@@ -36,7 +36,11 @@ export default function StayTunedSection() {
         <SocialIcon href="#" label="Instagram" className="hover:text-pink-400">
           <FaInstagram />
         </SocialIcon>
-        <SocialIcon href="https://discord.gg/jW43eTwe6J" label="Discord" className="hover:text-indigo-400">
+        <SocialIcon
+          href="https://discord.gg/jW43eTwe6J"
+          label="Discord"
+          className="hover:text-indigo-400"
+        >
           <FaDiscord />
         </SocialIcon>
       </div>

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { buyNft } from "~~/services/nft";
 
 type Tournament = {
   id: number;
@@ -211,9 +212,16 @@ export default function TournamentsTableSection() {
             </thead>
             <tbody className="bg-white dark:bg-black divide-y divide-gray-200 dark:divide-gray-800">
               {sorted.map((t) => (
-                <tr key={t.id} className="hover:bg-gray-50 dark:hover:bg-gray-900 transition">
+                <tr
+                  key={t.id}
+                  className="hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+                >
                   <td className="px-2 py-1">
-                    <img src={t.nft} alt={t.name} className="w-12 h-12 object-cover rounded" />
+                    <img
+                      src={t.nft}
+                      alt={t.name}
+                      className="w-12 h-12 object-cover rounded"
+                    />
                   </td>
                   <td className="px-2 py-1">{t.name}</td>
                   <td className="px-2 py-1">{t.game}</td>
@@ -226,13 +234,26 @@ export default function TournamentsTableSection() {
                     />
                     <span>{t.creator}</span>
                   </td>
-                  <td className="px-2 py-1 text-center text-yellow-400">{t.prize}%</td>
-                  <td className="px-2 py-1 text-center text-blue-400">{t.creatorShare}%</td>
-                  <td className="px-2 py-1 text-center text-red-400">{t.protocolFee}%</td>
-                  <td className="px-2 py-1 text-orange-500 text-center">{t.sold}/{t.supply}</td>
-                  <td className="px-2 py-1 text-green-500 text-center">${t.buyIn}</td>
+                  <td className="px-2 py-1 text-center text-yellow-400">
+                    {t.prize}%
+                  </td>
+                  <td className="px-2 py-1 text-center text-blue-400">
+                    {t.creatorShare}%
+                  </td>
+                  <td className="px-2 py-1 text-center text-red-400">
+                    {t.protocolFee}%
+                  </td>
+                  <td className="px-2 py-1 text-orange-500 text-center">
+                    {t.sold}/{t.supply}
+                  </td>
+                  <td className="px-2 py-1 text-green-500 text-center">
+                    ${t.buyIn}
+                  </td>
                   <td className="px-2 py-1 text-center">
-                    <button className="px-2 py-1 bg-purple-600 text-white rounded text-xs sm:text-sm hover:bg-purple-700">
+                    <button
+                      onClick={() => buyNft(t.id)}
+                      className="px-2 py-1 bg-purple-600 text-white rounded text-xs sm:text-sm hover:bg-purple-700"
+                    >
                       Buy
                     </button>
                   </td>

--- a/packages/nextjs/components/TrendingSection.tsx
+++ b/packages/nextjs/components/TrendingSection.tsx
@@ -1,8 +1,6 @@
 import { PopularNftCard, type PopularNftCardProps } from "./ui/PopularNftCard";
 
-type PopularNftItem = PopularNftCardProps & { id: number };
-
-const items: PopularNftItem[] = Array.from({ length: 7 }).map((_, i) => ({
+const items: PopularNftCardProps[] = Array.from({ length: 7 }).map((_, i) => ({
   id: i,
   title: `FIVE`,
   image: `/nfts/nft${i}.png`,

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -68,7 +68,7 @@ const ConnectModal = () => {
     <div>
       <label
         htmlFor="connect-modal"
-        className="rounded-[18px]  btn-sm font-bold px-8 bg-btn-wallet py-3 cursor-pointer"
+        className="rounded-full px-6 py-3 bg-gradient-to-r from-[#3B82F6] to-[#7C3AED] text-white font-bold shadow-lg hover:from-[#2563EB] hover:to-[#5B21B6] cursor-pointer"
       >
         <span>Connect</span>
       </label>

--- a/packages/nextjs/components/ui/NFTCard.tsx
+++ b/packages/nextjs/components/ui/NFTCard.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import Avatar from "./Avatar";
 import Badge from "./Badge";
 import Button from "./Button";
+import { buyNft } from "~~/services/nft";
 
 type NFTCardProps = {
+  id: number;
   title: string;
   image: string;
   creator: string;
@@ -15,6 +17,7 @@ type NFTCardProps = {
 };
 
 export const NFTCard: React.FC<NFTCardProps> = ({
+  id,
   title,
   image,
   creator,
@@ -32,7 +35,7 @@ export const NFTCard: React.FC<NFTCardProps> = ({
         className="object-cover transition-transform duration-300 group-hover:scale-105"
       />
       <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-        <Button>{actionLabel}</Button>
+        <Button onClick={() => buyNft(id)}>{actionLabel}</Button>
       </div>
       {badge && (
         <div className="absolute top-2 left-2">

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -1,7 +1,10 @@
 import Image from "next/image";
 import type { FC } from "react";
+import Button from "./Button";
+import { buyNft } from "~~/services/nft";
 
 export interface PopularNftCardProps {
+  id: number;
   image: string;
   title: string;
   buyIn: string;
@@ -15,6 +18,7 @@ export interface PopularNftCardProps {
 }
 
 export const PopularNftCard: FC<PopularNftCardProps> = ({
+  id,
   image,
   title,
   buyIn,
@@ -72,11 +76,9 @@ export const PopularNftCard: FC<PopularNftCardProps> = ({
         <span className="text-gray-400">PRIZE</span>
       </div>
     </div>
-    <div className="px-2 flex justify-between text-xs text-gray-600 font-medium pb-4">
-      <div className="flex flex-col"></div>
-      <div className="text-right">
-        <span className="text-gray-400">Rules</span>
-      </div>
+    <div className="px-2 flex justify-between items-center text-xs text-gray-600 font-medium pb-4">
+      <Button onClick={() => buyNft(id)}>Buy</Button>
+      <span className="text-gray-400">Rules</span>
     </div>
   </div>
 );

--- a/packages/nextjs/components/ui/WalletModal.tsx
+++ b/packages/nextjs/components/ui/WalletModal.tsx
@@ -11,7 +11,7 @@ export const WalletModal: React.FC = () => {
         {connected ? "Wallet" : "Connect Wallet"}
       </Button>
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
           <div className="bg-primary p-6 rounded-md w-80">
             {connected ? (
               <div className="space-y-4">

--- a/packages/nextjs/services/nft.ts
+++ b/packages/nextjs/services/nft.ts
@@ -1,0 +1,6 @@
+export async function buyNft(id: number | string) {
+  // Placeholder for integrating Starknet contract call
+  // eslint-disable-next-line no-alert
+  alert(`Buying NFT ${id}`);
+  console.log(`Buying NFT ${id}`);
+}

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -178,3 +178,18 @@ body {
     clip-path: polygon(100% 100%, 100% 0, 90% 100%);
   }
 }
+
+@keyframes marquee {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+@layer utilities {
+  .animate-marquee {
+    animation: marquee 20s linear infinite;
+  }
+}


### PR DESCRIPTION
## Summary
- Center hero text with animated play button
- Style connect wallet button and raise wallet modal z-index
- Add marquee mission statement and hover effects
- Add buy hooks for NFT cards and tournament table

## Testing
- `yarn next:lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `yarn test:nextjs` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689326b4d7ec8324b624673a03084f0c