### PR TITLE
fix: improve wallet modal layering and nav styles

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -46,7 +46,7 @@ export const HeaderMenuLinks = () => {
               passHref
               className={`${
                 isActive ? "animate-pulse" : ""
-              } px-4 py-2 text-sm font-semibold rounded-lg gap-2 grid grid-flow-col bg-yellow-400 text-[#0c1a3a] shadow-[0_0_15px_#facc15] hover:shadow-[0_0_20px_#facc15]`}
+              } px-4 py-2 text-sm font-semibold rounded-lg gap-2 grid grid-flow-col text-white hover:bg-yellow-400 hover:text-[#0c1a3a] hover:shadow-[0_0_20px_#facc15]`}
             >
               {icon}
               <span>{label}</span>

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -10,7 +10,7 @@ const steps = [
 
 export default function HowItWorksSection() {
   return (
-    <section className="bg-black text-white py-16 px-4">
+    <section className="bg-black text-white py-16 px-4 sm:px-6 md:px-12">
       <div className="max-w-6xl mx-auto">
         <h2 className="text-3xl sm:text-4xl font-bold text-center mb-12">
           Create Your Own <span className="text-yellow-400">POKER</span>{" "}

--- a/packages/nextjs/components/MarketplaceSection.tsx
+++ b/packages/nextjs/components/MarketplaceSection.tsx
@@ -15,9 +15,9 @@ export default function MarketplaceSection() {
   return (
     <section
       id="marketplace"
-      className="py-12 px-4 sm:px-6 bg-white dark:bg-gray-900"
+      className="py-12 px-4 sm:px-6 md:px-12 bg-white dark:bg-gray-900"
     >
-      <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-6">
+      <div className="max-w-6xl mx-auto grid md:grid-cols-12 gap-6">
         <div className="md:col-span-3 mb-6 md:mb-0">
           <FiltersSidebar />
         </div>

--- a/packages/nextjs/components/TrendingSection.tsx
+++ b/packages/nextjs/components/TrendingSection.tsx
@@ -21,16 +21,18 @@ export default function TrendingSection() {
   return (
     <section
       id="trending"
-      className="py-12 px-4 sm:px-6 md:px-12 bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
+      className="py-12 bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
     >
-      <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
-        Trending
-      </h2>
-      <div className="overflow-x-auto pb-2">
-        <div className="grid grid-cols-7 gap-4 md:gap-6 w-max">
-          {items.map((item) => (
-            <PopularNftCard key={item.id} {...item} />
-          ))}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
+        <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
+          Trending
+        </h2>
+        <div className="overflow-x-auto pb-2">
+          <div className="grid grid-cols-7 gap-4 md:gap-6 w-max">
+            {items.map((item) => (
+              <PopularNftCard key={item.id} {...item} />
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -64,14 +64,21 @@ const ConnectModal = () => {
     }
   }
 
+  const handleOpenModal = () => {
+    if (modalRef.current) {
+      modalRef.current.checked = true;
+    }
+  };
+
   return (
     <div>
-      <label
-        htmlFor="connect-modal"
-        className="px-8 py-4 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_#facc15] hover:shadow-[0_0_20px_#facc15] animate-pulse cursor-pointer"
+      <button
+        type="button"
+        onClick={handleOpenModal}
+        className="px-8 py-4 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_#facc15] hover:shadow-[0_0_20px_#facc15] animate-pulse"
       >
         <span>Connect</span>
-      </label>
+      </button>
 
       <input
         ref={modalRef}

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/GenericModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/GenericModal.tsx
@@ -19,7 +19,7 @@ const GenericModal = ({
   const modal = (
     <label
       htmlFor={modalId}
-      className="modal z-[1000] backdrop-blur cursor-pointer"
+      className="modal z-[10000] backdrop-blur cursor-pointer"
     >
       <label className={className}>
         {/* dummy input to capture event onclick on modal box */}

--- a/packages/nextjs/components/ui/WalletModal.tsx
+++ b/packages/nextjs/components/ui/WalletModal.tsx
@@ -11,7 +11,7 @@ export const WalletModal: React.FC = () => {
         {connected ? "Wallet" : "Connect Wallet"}
       </Button>
       {open && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50">
           <div className="bg-primary p-6 rounded-md w-80">
             {connected ? (
               <div className="space-y-4">

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -63,7 +63,7 @@ body {
 }
 
 .modal {
-  @apply overflow-hidden z-[9999];
+  @apply overflow-hidden z-[10000];
 }
 
 .modal-box {


### PR DESCRIPTION
## Summary
- ensure wallet modals render above all other elements
- update navbar links to show yellow styling only on hover
- align widths for How It Works, Trending and Marketplace sections
- replace static label with functional button so Connect Wallet opens modal

## Testing
- `npm run next:lint`
- `npm test -- --run` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_6893866d0dec8324b77873d326626faa