### PR TITLE
fix: ensure wallet modal visibility

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -21,7 +21,6 @@ const menuLinks: HeaderMenuLink[] = [
 ];
 
 const NavLinks = ({ close }: { close?: () => void }) => {
-
   return (
     <>
       {menuLinks.map(({ label, href }) => (
@@ -29,13 +28,11 @@ const NavLinks = ({ close }: { close?: () => void }) => {
           <Link
             href={href}
             className="px-4 py-2 text-sm font-semibold rounded-lg text-white hover:bg-yellow-400 hover:text-[#0c1a3a]"
-
           >
             {label}
           </Link>
         </li>
       ))}
-
     </>
   );
 };

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -58,7 +58,7 @@ export default function HeroSection() {
         </div>
       ))}
 
-      <div className="absolute inset-0 bg-black/40" />
+      <div className="absolute inset-0 bg-black/40 pointer-events-none" />
 
       <div className="relative z-10 h-full flex flex-col justify-center items-center text-center px-6 md:px-12">
         <h1 className="text-3xl md:text-5xl font-bold mb-6">

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -86,6 +86,8 @@ body {
   filter: blur(229px);
   position: absolute;
   top: 0;
+  pointer-events: none;
+  z-index: -1;
 }
 
 .circle-gradient-blue {
@@ -95,6 +97,8 @@ body {
   position: absolute;
   top: 0;
   right: 0;
+  pointer-events: none;
+  z-index: -1;
 }
 
 .border-gradient {
@@ -146,6 +150,8 @@ body {
   border-radius: 630px;
   background: #7c3aed;
   filter: blur(229px);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .circle-gradient-blue-dark {
@@ -155,6 +161,8 @@ body {
   position: absolute;
   top: 0;
   right: 0;
+  pointer-events: none;
+  z-index: -1;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- prevent gradient background elements from blocking interactions by placing them behind content
- allow hero overlay to ignore pointer events so wallet modal shows above hero section

## Testing
- `yarn next:lint`
- `yarn next:check-types`
- `yarn test:nextjs --run`


------
https://chatgpt.com/codex/tasks/task_e_6893a74a31308324bc09bc504cebaa4f