### PR TITLE
feat: refresh accent palette with neon yellow

### DIFF
--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -66,7 +66,7 @@ export default function HeroSection() {
         </h1>
         <a
           href="/play"
-          className="px-8 py-4 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_#facc15] animate-pulse hover:shadow-[0_0_20px_#facc15]"
+          className="px-8 py-4 bg-accent text-primary font-semibold rounded-lg shadow-neon animate-pulse hover:shadow-neon-hover"
         >
           Play
         </a>
@@ -93,7 +93,7 @@ export default function HeroSection() {
             key={i}
             onClick={() => setIndex(i)}
             className={`w-3 h-3 rounded-full ${
-              i === index ? "bg-yellow-400" : "bg-white/50"
+              i === index ? "bg-accent" : "bg-white/50"
             }`}
             aria-label={`Go to slide ${i + 1}`}
           />

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -13,7 +13,7 @@ export default function HowItWorksSection() {
     <section id="how" className="bg-black text-white py-16">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
         <h2 className="text-3xl sm:text-4xl font-bold text-center mb-12">
-          Create Your Own <span className="text-yellow-400">POKER</span>{" "}
+          Create Your Own <span className="text-accent">POKER</span>{" "}
           Tournament
         </h2>
 
@@ -58,7 +58,7 @@ export default function HowItWorksSection() {
           <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
             <h3 className="text-xl font-semibold mb-2">Fund Distribution</h3>
             <p>
-              Funds split: <span className="text-yellow-400">80%</span> prizes,{" "}
+              Funds split: <span className="text-accent">80%</span> prizes,{" "}
               <span className="text-blue-400">10%</span> creator,{" "}
               <span className="text-pink-400">10%</span> protocol.
             </p>

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -35,7 +35,7 @@ export default function PlayerSeat({
     >
       {/* Dealer marker */}
       {isDealer && (
-        <span className="absolute -top-3 -right-3 w-6 h-6 rounded-full bg-yellow-400 text-black text-xs font-bold flex items-center justify-center">
+        <span className="absolute -top-3 -right-3 w-6 h-6 rounded-full bg-accent text-black text-xs font-bold flex items-center justify-center">
           D
         </span>
       )}

--- a/packages/nextjs/components/StayTunedSection.tsx
+++ b/packages/nextjs/components/StayTunedSection.tsx
@@ -14,7 +14,7 @@ export default function StayTunedSection() {
       {/* subtle radial glow */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-800/10 via-indigo-600/10 to-purple-700/10 rounded-[40%] blur-[180px] -z-10" />
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12 text-center">
-        <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-yellow-300">
+        <h2 className="text-3xl md:text-4xl font-extrabold tracking-wide text-accent">
           Highlights & Community
         </h2>
         <p className="max-w-xl mx-auto mt-4 text-slate-300">

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -194,7 +194,7 @@ export default function TournamentsTableSection() {
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
         <h2 className="text-3xl font-bold mb-6">
-          <span className="text-yellow-400">Tournaments</span>
+          <span className="text-accent">Tournaments</span>
         </h2>
         <div className="overflow-auto rounded-lg border border-gray-300 dark:border-gray-700">
           <table className="min-w-full text-xs sm:text-sm table-auto">
@@ -237,7 +237,7 @@ export default function TournamentsTableSection() {
                     />
                     <span>{t.creator}</span>
                   </td>
-                  <td className="px-2 py-1 text-center text-yellow-400">
+                  <td className="px-2 py-1 text-center text-accent">
                     {t.prize}%
                   </td>
                   <td className="px-2 py-1 text-center text-blue-400">

--- a/packages/nextjs/components/ui/PopularNftCard.tsx
+++ b/packages/nextjs/components/ui/PopularNftCard.tsx
@@ -56,7 +56,7 @@ export const PopularNftCard: FC<PopularNftCardProps> = ({
         </div>
       </div>
       <div className="text-right">
-        <span className="ml-1 text-yellow-400">{dateTime}</span>
+        <span className="ml-1 text-accent">{dateTime}</span>
         <br />
         <span className="text-xs text-gray-500 font-medium">
           {tournamentType}

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -5,9 +5,9 @@
 
 :root {
   --color-primary: #0a0a0a;
-  --color-accent: #00ffd1;
-  --color-secondary: #ff5f5f;
-  --color-highlight: #ffd700;
+  --color-accent: #ccff00;
+  --color-secondary: #4b0082;
+  --color-highlight: #800020;
   --color-background: #e5e5e5;
   --color-border: #2a2a2a;
 }
@@ -20,10 +20,10 @@ body {
   background-image:
     radial-gradient(
       circle at 20% 20%,
-      rgba(0, 255, 209, 0.15),
+      rgba(204, 255, 0, 0.15),
       transparent 40%
     ),
-    radial-gradient(circle at 80% 0%, rgba(255, 95, 95, 0.15), transparent 40%);
+    radial-gradient(circle at 80% 0%, rgba(75, 0, 130, 0.15), transparent 40%);
 }
 
 h1,
@@ -82,7 +82,7 @@ body {
 
 .circle-gradient {
   border-radius: 630px;
-  background: #93c5fd;
+  background: #4b0082;
   filter: blur(229px);
   position: absolute;
   top: 0;
@@ -92,7 +92,7 @@ body {
 
 .circle-gradient-blue {
   border-radius: 630px;
-  background: #d8b4fe;
+  background: #800020;
   filter: blur(250px);
   position: absolute;
   top: 0;
@@ -102,7 +102,7 @@ body {
 }
 
 .border-gradient {
-  border: 1px solid #7c3aed;
+  border: 1px solid #4b0082;
 }
 
 .bg-modal {
@@ -136,19 +136,20 @@ body {
     width: 1rem;
     height: 1rem;
     background: inherit;
-    border-top: 1px solid #7c3aed;
-    border-right: 1px solid #7c3aed;
+    border-top: 1px solid #4b0082;
+    border-right: 1px solid #4b0082;
     clip-path: polygon(100% 0, 0 0, 100% 100%);
     z-index: 10;
   }
 }
+
 
 .circle-gradient-dark {
   position: absolute;
   top: 0;
   left: 60px;
   border-radius: 630px;
-  background: #7c3aed;
+  background: #4b0082;
   filter: blur(229px);
   pointer-events: none;
   z-index: -1;
@@ -156,7 +157,7 @@ body {
 
 .circle-gradient-blue-dark {
   border-radius: 630px;
-  background: #38bdf8;
+  background: #800020;
   filter: blur(250px);
   position: absolute;
   top: 0;
@@ -171,7 +172,7 @@ body {
     height: 6px;
     clip-path: polygon(10% 100%, 90% 100%, 100% 0, 0 0);
     position: relative;
-    background-color: #7c3aed;
+    background-color: #4b0082;
     position: absolute;
     top: -1px;
   }

--- a/packages/nextjs/tailwind.config.ts
+++ b/packages/nextjs/tailwind.config.ts
@@ -17,9 +17,9 @@ const config: Config = {
         light: {
           primary: "#3B82F6",
           "primary-content": "#FFFFFF",
-          secondary: "#7C3AED",
+          secondary: "#4B0082",
           "secondary-content": "#FFFFFF",
-          accent: "#38BDF8",
+          accent: "#CCFF00",
           "accent-content": "#1F2937",
           neutral: "#1F2937",
           "neutral-content": "#FFFFFF",
@@ -33,32 +33,32 @@ const config: Config = {
           error: "#EF4444",
           ".bg-gradient-modal": {
             "background-image":
-              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
+              "linear-gradient(270deg,#CCFF00 -17.42%, #4B0082 109.05%)",
           },
           ".bg-modal": {
             background:
               "linear-gradient(270deg,#F3F4F6 -17.42%, #E0E7FF 109.05%)",
           },
           ".modal-border": {
-            border: "1px solid #7C3AED",
+            border: "1px solid #4B0082",
           },
           ".bg-gradient-nav": {
-            background: "linear-gradient(90deg,#3B82F6 0%, #7C3AED 100%)",
+            background: "linear-gradient(90deg,#CCFF00 0%, #4B0082 100%)",
           },
           ".bg-main": {
             background:
-              "radial-gradient(at 50% 0%, rgba(147,197,253,0.4), rgba(216,180,254,0.2) 60%), #FFFFFF",
+              "radial-gradient(at 50% 0%, rgba(204,255,0,0.4), rgba(75,0,130,0.2) 60%), #FFFFFF",
           },
           ".bg-underline": {
             background:
-              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
+              "linear-gradient(270deg,#CCFF00 -17.42%, #4B0082 109.05%)",
           },
           ".bg-container": {
             background: "transparent",
           },
           ".bg-btn-wallet": {
             "background-image":
-              "linear-gradient(90deg,#3B82F6 0%, #7C3AED 100%)",
+              "linear-gradient(90deg,#CCFF00 0%, #4B0082 100%)",
           },
           ".bg-input": {
             background: "rgba(0, 0, 0, 0.05)",
@@ -68,13 +68,13 @@ const config: Config = {
           },
           ".bg-function": {
             background:
-              "linear-gradient(270deg,#93C5FD -17.42%, #D8B4FE 109.05%)",
+              "linear-gradient(270deg,#CCFF00 -17.42%, #4B0082 109.05%)",
           },
           ".text-function": {
-            color: "#7C3AED",
+            color: "#4B0082",
           },
           ".text-network": {
-            color: "#3B82F6",
+            color: "#800020",
           },
           "--rounded-btn": "9999rem",
           ".tooltip": {
@@ -95,9 +95,9 @@ const config: Config = {
         dark: {
           primary: "#0A0A0A",
           "primary-content": "#E5E5E5",
-          secondary: "#FF5F5F",
+          secondary: "#800020",
           "secondary-content": "#0A0A0A",
-          accent: "#00FFD1",
+          accent: "#CCFF00",
           "accent-content": "#0A0A0A",
           neutral: "#1A1A1A",
           "neutral-content": "#E5E5E5",
@@ -105,10 +105,10 @@ const config: Config = {
           "base-200": "#1A1A1A",
           "base-300": "#2A2A2A",
           "base-content": "#E5E5E5",
-          info: "#00FFD1",
+          info: "#CCFF00",
           success: "#2ECC71",
           warning: "#FFD700",
-          error: "#FF5F5F",
+          error: "#800020",
           ".bg-gradient-modal": {
             background: "#1A1A1A",
           },
@@ -116,15 +116,15 @@ const config: Config = {
             background: "linear-gradient(90deg,#0A0A0A 0%, #1A1A1A 100%)",
           },
           ".modal-border": {
-            border: "1px solid #00FFD1",
+            border: "1px solid #CCFF00",
           },
           ".bg-gradient-nav": {
             "background-image":
-              "linear-gradient(90deg,#00FFD1 0%,rgb(14, 19, 150) 100%)",
+              "linear-gradient(90deg,#CCFF00 0%,#4B0082 100%)",
           },
           ".bg-main": {
             background:
-              "radial-gradient(at 50% 0%, rgba(20, 14, 81, 0.15), rgba(19, 10, 79, 0.1) 60%), #0A0A0A",
+              "radial-gradient(at 50% 0%, rgba(75,0,130,0.15), rgba(128,0,32,0.1) 60%), #0A0A0A",
           },
           ".bg-underline": {
             background: "#2A2A2A",
@@ -134,7 +134,7 @@ const config: Config = {
           },
           ".bg-btn-wallet": {
             "background-image":
-              "linear-gradient(180deg,#00FFD1 0%, #FF5F5F 100%)",
+              "linear-gradient(180deg,#CCFF00 0%, #800020 100%)",
           },
           ".bg-input": {
             background: "rgba(255, 255, 255, 0.07)",
@@ -144,13 +144,13 @@ const config: Config = {
               "linear-gradient(113deg,rgba(10,10,10,0.6) 20.48%,rgba(26,26,26,0.6) 99.67%)",
           },
           ".bg-function": {
-            background: "rgba(0,255,209,0.2)",
+            background: "rgba(204,255,0,0.2)",
           },
           ".text-function": {
-            color: "#00FFD1",
+            color: "#CCFF00",
           },
           ".text-network": {
-            color: "#FF5F5F",
+            color: "#800020",
           },
           "--rounded-btn": "9999rem",
           ".tooltip": {
@@ -175,24 +175,25 @@ const config: Config = {
     extend: {
       boxShadow: {
         center: "0 0 12px -2px rgb(0 0 0 / 0.05)",
-        neon: "0 0 10px 0 rgba(0,255,209,0.7)",
-        "neon-red": "0 0 10px 0 rgba(255,95,95,0.7)",
+        neon: "0 0 15px 0 rgba(204,255,0,0.7)",
+        "neon-hover": "0 0 20px 0 rgba(204,255,0,0.7)",
+        "neon-red": "0 0 10px 0 rgba(128,0,32,0.7)",
       },
       animation: {
         "pulse-fast": "pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite",
       },
       backgroundImage: {
         "gradient-light":
-          "linear-gradient(270deg,#00FFD1 -17.42%, #FF5F5F 109.05%)",
-        "gradient-dark": "linear-gradient(90deg,#00FFD1 0%, #FF5F5F 100%)",
-        "gradient-vertical": "linear-gradient(180deg,#00FFD1 0%, #FF5F5F 100%)",
-        "gradient-icon": "linear-gradient(90deg,#00FFD1 0%, #FF5F5F 100%)",
+          "linear-gradient(270deg,#CCFF00 -17.42%, #4B0082 109.05%)",
+        "gradient-dark": "linear-gradient(90deg,#CCFF00 0%, #800020 100%)",
+        "gradient-vertical": "linear-gradient(180deg,#CCFF00 0%, #4B0082 100%)",
+        "gradient-icon": "linear-gradient(90deg,#CCFF00 0%, #800020 100%)",
       },
       colors: {
         primary: "#0A0A0A",
-        accent: "#00FFD1",
-        secondary: "#FF5F5F",
-        highlight: "#FFD700",
+        accent: "#CCFF00",
+        secondary: "#4B0082",
+        highlight: "#800020",
         background: "#1A1A1A",
         border: "#2A2A2A",
       },


### PR DESCRIPTION
## Summary
- switch global accent to neon yellow and add richer purple/wine gradients
- update tailwind gradients, box shadows and colors to use new palette
- refactor components to consume accent classes instead of hardcoded yellows

## Testing
- `yarn next:lint` *(fails: project not installed)*
- `yarn install` *(fails: unrs-resolver couldn't be built)*
- `yarn test:nextjs` *(fails: Cannot read properties of undefined reading '.pnp.cjs')*

------
https://chatgpt.com/codex/tasks/task_e_6894092d96cc83249d84c1db25eac72e