### PR TITLE
feat: enhance hero with dreamlike motion

### DIFF
--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -53,11 +53,12 @@ export default function HeroSection() {
             alt={s.title}
             fill
             priority={i === index}
-            className="object-cover"
+            className="object-cover scale-105 animate-parallax"
           />
         </div>
       ))}
 
+      <div className="absolute inset-0 hero-overlay pointer-events-none animate-dream" />
       <div className="absolute inset-0 bg-black/40 pointer-events-none" />
 
       <div className="relative z-10 h-full flex flex-col justify-center items-center text-center px-6 md:px-12">
@@ -66,7 +67,7 @@ export default function HeroSection() {
         </h1>
         <a
           href="/play"
-          className="px-8 py-4 bg-yellow-400 text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_#facc15] animate-pulse hover:shadow-[0_0_20px_#facc15]"
+          className="px-8 py-4 bg-[var(--color-neon-yellow)] text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_var(--color-neon-yellow)] animate-pulse hover:shadow-[0_0_20px_var(--color-neon-yellow)]"
         >
           Play
         </a>
@@ -93,7 +94,7 @@ export default function HeroSection() {
             key={i}
             onClick={() => setIndex(i)}
             className={`w-3 h-3 rounded-full ${
-              i === index ? "bg-yellow-400" : "bg-white/50"
+              i === index ? "bg-[var(--color-neon-yellow)]" : "bg-white/50"
             }`}
             aria-label={`Go to slide ${i + 1}`}
           />

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -10,6 +10,7 @@
   --color-highlight: #ffd700;
   --color-background: #e5e5e5;
   --color-border: #2a2a2a;
+  --color-neon-yellow: #e0ff00;
 }
 
 body {
@@ -165,6 +166,21 @@ body {
   z-index: -1;
 }
 
+.hero-overlay {
+  mix-blend-mode: overlay;
+  background:
+    radial-gradient(
+      circle at 30% 30%,
+      rgba(224, 255, 0, 0.15),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 70% 70%,
+      rgba(0, 255, 209, 0.15),
+      transparent 60%
+    );
+}
+
 @layer utilities {
   .trapeze {
     width: 84px;
@@ -199,5 +215,39 @@ body {
 @layer utilities {
   .animate-marquee {
     animation: marquee 20s linear infinite;
+  }
+}
+
+@keyframes parallax {
+  0% {
+    transform: scale(1.05) translate(0, 0);
+  }
+  50% {
+    transform: scale(1.1) translate(-2%, -2%);
+  }
+  100% {
+    transform: scale(1.05) translate(0, 0);
+  }
+}
+
+@keyframes dream {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 100% 100%;
+  }
+  100% {
+    background-position: 0% 0%;
+  }
+}
+
+@layer utilities {
+  .animate-parallax {
+    animation: parallax 30s ease-in-out infinite;
+  }
+  .animate-dream {
+    background-size: 200% 200%;
+    animation: dream 40s ease-in-out infinite;
   }
 }


### PR DESCRIPTION
## Summary
- swap hero yellow accents for new neon variable
- overlay surreal gradients and parallax motion on hero carousel

## Testing
- `yarn install` (fails: unrs-resolver@npm:1.11.1 couldn't be built)
- `yarn next:lint` (fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))
- `yarn test:nextjs` (fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))


------
https://chatgpt.com/codex/tasks/task_e_6894095b2c4c8324be59b0c3ecbd0e3a