### PR TITLE
style: unify buttons with header menu link

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -16,12 +16,6 @@ export default function PlayPage() {
     <main className="min-h-screen flex flex-col items-center text-white">
       <header className="relative w-full max-w-6xl flex items-center justify-between mt-6 mb-4 px-4">
         <h1 className="text-4xl font-bold">Poker Night on Starknet</h1>
-        <button
-          className="absolute left-1/2 -translate-x-1/2 btn"
-          onClick={() => alert("join logic TBD")}
-        >
-          Join Table
-        </button>
         <div className="flex items-center gap-4">
           <ActionBar
             street={stageNames[street] ?? "preflop"}

--- a/packages/nextjs/components/ActionBar.tsx
+++ b/packages/nextjs/components/ActionBar.tsx
@@ -11,22 +11,34 @@ export default function ActionBar({ street, ...actions }: Props) {
   return (
     <div className="flex gap-4 card p-2 rounded-full">
       {street === "preflop" && (
-        <button onClick={actions.onFlop} className="btn">
+        <button
+          onClick={actions.onFlop}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+        >
           Deal Flop
         </button>
       )}
       {street === "flop" && (
-        <button onClick={actions.onTurn} className="btn">
+        <button
+          onClick={actions.onTurn}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+        >
           Deal Turn
         </button>
       )}
       {street === "turn" && (
-        <button onClick={actions.onRiver} className="btn">
+        <button
+          onClick={actions.onRiver}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+        >
           Deal River
         </button>
       )}
       {street === "river" && (
-        <button onClick={actions.onStart} className="btn">
+        <button
+          onClick={actions.onStart}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+        >
           New Hand
         </button>
       )}

--- a/packages/nextjs/components/HeroSection.tsx
+++ b/packages/nextjs/components/HeroSection.tsx
@@ -67,8 +67,7 @@ export default function HeroSection() {
         </h1>
         <a
           href="/play"
-          className="px-8 py-4 bg-[var(--color-neon-yellow)] text-[#0c1a3a] font-semibold rounded-lg shadow-[0_0_15px_var(--color-neon-yellow)] animate-pulse hover:shadow-[0_0_20px_var(--color-neon-yellow)]"
-
+          className="px-8 py-4 text-sm rounded-full font-serif-renaissance bg-[var(--color-neon-yellow)] text-[#0c1a3a] shadow-[0_0_15px_var(--color-neon-yellow)] hover:bg-gradient-nav hover:text-white hover:shadow-none"
         >
           Play
         </a>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -68,7 +68,7 @@ const ConnectModal = () => {
     <div>
       <label
         htmlFor="connect-modal"
-        className="rounded-[18px]  btn-sm font-bold px-8 bg-btn-wallet py-3 cursor-pointer"
+        className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance cursor-pointer hover:bg-gradient-nav hover:text-white"
       >
         <span>Connect</span>
       </label>


### PR DESCRIPTION
## Summary
- restyle hero Play button with HeaderMenuLink theme
- reuse HeaderMenuLink styling for action and connect buttons
- drop temporary join table button

## Testing
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*


------
https://chatgpt.com/codex/tasks/task_e_6894197e1c1c8324923b97cab8fbd02f