### PR TITLE
Revamp styling for main page sections

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -10,7 +10,7 @@ import MissionStatementSection from "../components/MissionStatementSection";
 
 export default function HomePage() {
   return (
-    <main className="flex flex-col items-stretch">
+    <main className="flex flex-col items-stretch space-y-24">
       <HeroSection />
       <MissionStatementSection />
       <HowItWorksSection />

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -1,77 +1,75 @@
 import React from "react";
+import {
+  FaImage,
+  FaTags,
+  FaUsers,
+  FaTable,
+  FaCoins,
+  FaGift,
+} from "react-icons/fa";
 
 const steps = [
-  "Connect your wallet",
-  "Join a table",
-  "Get your cards",
-  "Play the rounds",
-  "Win the pot",
+  {
+    title: "Create an NFT",
+    description:
+      "Upload your own artwork. This NFT will represent your tournament entry ticket.",
+    icon: FaImage,
+  },
+  {
+    title: "Set Price, Supply & Date",
+    description:
+      "Choose your buy-in price, total supply, and tournament start date.",
+    icon: FaTags,
+  },
+  {
+    title: "Bring Your Followers",
+    description:
+      "Share and sell your NFT to your community. Each buyer gets a seat at the table!",
+    icon: FaUsers,
+  },
+  {
+    title: "Protocol Spins Up a Table",
+    description:
+      "Once funded, the protocol automatically launches a secure onchain poker game.",
+    icon: FaTable,
+  },
+  {
+    title: "Fund Distribution",
+    description:
+      "Funds split: 80% prizes, 10% creator, 10% protocol.",
+    icon: FaCoins,
+  },
+  {
+    title: "Get $POKER Airdrop",
+    description:
+      "Top 15% win prize money and get a bonus airdrop of $POKER tokens.",
+    icon: FaGift,
+  },
 ];
 
 export default function HowItWorksSection() {
   return (
-    <section id="how" className="bg-black text-white py-16">
+    <section
+      id="how"
+      className="bg-gradient-to-b from-gray-900 via-black to-gray-900 text-white py-24"
+    >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
-        <h2 className="text-3xl sm:text-4xl font-bold text-center mb-12">
-          Create Your Own <span className="text-accent">POKER</span>{" "}
-          Tournament
+        <h2 className="text-3xl sm:text-4xl font-bold text-center mb-16">
+          Create Your Own <span className="text-accent">POKER</span> Tournament
         </h2>
-
-        <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">Create an NFT</h3>
-            <p>
-              Upload your own artwork. This NFT will represent your tournament
-              entry ticket.
-            </p>
-          </div>
-
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">
-              Set Price, Supply & Date
-            </h3>
-            <p>
-              Choose your buy-in price, total supply, and tournament start date.
-            </p>
-          </div>
-
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">
-              Bring Your Followers
-            </h3>
-            <p>
-              Share and sell your NFT to your community. Each buyer gets a seat
-              at the table!
-            </p>
-          </div>
-
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">
-              Protocol Spins Up a Table
-            </h3>
-            <p>
-              Once funded, the protocol automatically launches a secure onchain
-              poker game.
-            </p>
-          </div>
-
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">Fund Distribution</h3>
-            <p>
-              Funds split: <span className="text-accent">80%</span> prizes,{" "}
-              <span className="text-blue-400">10%</span> creator,{" "}
-              <span className="text-pink-400">10%</span> protocol.
-            </p>
-          </div>
-
-          <div className="bg-gray-900 border border-gray-700 p-6 rounded-lg transition-transform hover:scale-105 hover:shadow-lg">
-            <h3 className="text-xl font-semibold mb-2">
-             Get $POKER Airdrop
-            </h3>
-            <p>
-              Top 15% win prize money and get a bonus airdrop of $POKER tokens.
-            </p>
-          </div>
+        <div className="grid gap-12 sm:grid-cols-2 lg:grid-cols-3">
+          {steps.map(({ title, description, icon: Icon }, index) => (
+            <div
+              key={index}
+              className="relative p-6 rounded-xl bg-gray-900/60 border border-gray-800 shadow-center transition-transform hover:-translate-y-1 hover:shadow-neon"
+            >
+              <div className="flex items-center justify-center w-12 h-12 mb-4 rounded-full bg-accent/20 text-accent text-xl">
+                <Icon />
+              </div>
+              <h3 className="text-xl font-semibold mb-2">{title}</h3>
+              <p className="text-gray-300 text-sm">{description}</p>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/packages/nextjs/components/MissionStatementSection.tsx
+++ b/packages/nextjs/components/MissionStatementSection.tsx
@@ -5,9 +5,9 @@ const message =
 
 export default function MissionStatementSection() {
   return (
-    <section className="bg-black text-white py-4 overflow-hidden">
+    <section className="bg-gradient-to-r from-secondary/20 via-black to-secondary/20 text-white py-6 overflow-hidden">
       <div className="whitespace-nowrap">
-        <div className="animate-marquee inline-block">
+        <div className="animate-marquee inline-block text-lg tracking-wide">
           <span className="mx-8">{message}</span>
           <span className="mx-8">{message}</span>
           <span className="mx-8">{message}</span>

--- a/packages/nextjs/components/StayTunedSection.tsx
+++ b/packages/nextjs/components/StayTunedSection.tsx
@@ -8,8 +8,8 @@ export default function StayTunedSection() {
   return (
     <section
       id="community"
-      className="relative py-24 overflow-hidden"
-    >      
+      className="relative py-24 overflow-hidden bg-gradient-to-b from-black via-gray-900 to-black text-white"
+    >
 
       {/* subtle radial glow */}
       <div className="absolute inset-0 bg-gradient-to-br from-blue-800/10 via-indigo-600/10 to-purple-700/10 rounded-[40%] blur-[180px] -z-10" />

--- a/packages/nextjs/components/TournamentsTableSection.tsx
+++ b/packages/nextjs/components/TournamentsTableSection.tsx
@@ -190,10 +190,10 @@ export default function TournamentsTableSection() {
   return (
     <section
       id="tournaments"
-      className="py-4 sm:py-8 bg-white text-gray-900 dark:bg-black dark:text-white"
+      className="py-24 bg-gradient-to-b from-white via-gray-50 to-white text-gray-900 dark:from-gray-900 dark:via-black dark:to-gray-900 dark:text-white"
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
-        <h2 className="text-3xl font-bold mb-6">
+        <h2 className="text-3xl font-bold text-center mb-8">
           <span className="text-accent">Tournaments</span>
         </h2>
         <div className="overflow-auto rounded-lg border border-gray-300 dark:border-gray-700">

--- a/packages/nextjs/components/TrendingSection.tsx
+++ b/packages/nextjs/components/TrendingSection.tsx
@@ -21,11 +21,11 @@ export default function TrendingSection() {
   return (
     <section
       id="trending"
-      className="py-12 text-gray-900 dark:text-white"
+      className="py-24 bg-gradient-to-b from-black via-gray-900 to-black text-white"
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
-        <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-8">
-          Trending
+        <h2 className="text-3xl md:text-4xl font-extrabold text-center mb-10">
+          <span className="text-accent">Trending</span>
         </h2>
         <div className="overflow-x-auto pb-2">
           <div className="grid grid-cols-7 gap-4 md:gap-6 w-max">


### PR DESCRIPTION
## Summary
- space out page sections for clearer layout
- modernize mission statement and social/community areas with gradients
- rebuild How It Works as icon-based step cards
- apply gradient styling to trending and tournament table sections

## Testing
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn install` *(fails: unrs-resolver couldn't be built)*
- `yarn next:lint` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_68941fafb00c83249c75c52566ee5572