### PR TITLE
feat: add basic poker game room logic

### DIFF
--- a/packages/nextjs/game/room.test.ts
+++ b/packages/nextjs/game/room.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { dealDeck } from "./utils";
+import {
+  addPlayer,
+  createRoom,
+  determineWinners,
+  handleAction,
+  nextTurn,
+} from "./room";
+import { GameRoom } from "./types";
+
+describe("dealDeck", () => {
+  it("returns 52 unique cards", () => {
+    const deck = dealDeck();
+    expect(deck).toHaveLength(52);
+    const uniq = new Set(deck.map((c) => c.rank + c.suit));
+    expect(uniq.size).toBe(52);
+  });
+});
+
+describe("turn management", () => {
+  it("skips folded players", () => {
+    const room = createRoom("r");
+    addPlayer(room, { id: "p1", nickname: "A", seat: 0, chips: 100 });
+    addPlayer(room, { id: "p2", nickname: "B", seat: 1, chips: 100 });
+    addPlayer(room, { id: "p3", nickname: "C", seat: 2, chips: 100 });
+    room.players[1].hasFolded = true;
+    room.currentTurnIndex = 0;
+    nextTurn(room);
+    expect(room.currentTurnIndex).toBe(2);
+    expect(room.players[2].isTurn).toBe(true);
+  });
+});
+
+describe("betting and showdown", () => {
+  it("updates chips and pot", () => {
+    const room = createRoom("r");
+    const p1 = addPlayer(room, { id: "p1", nickname: "A", seat: 0, chips: 100 });
+    const p2 = addPlayer(room, { id: "p2", nickname: "B", seat: 1, chips: 100 });
+    handleAction(room, p1.id, { type: "raise", amount: 20 });
+    handleAction(room, p2.id, { type: "call" });
+    expect(room.pot).toBe(40);
+    expect(p1.chips).toBe(80);
+    expect(p2.chips).toBe(80);
+  });
+
+  it("finds high-card winner", () => {
+    const room: GameRoom = {
+      id: "r",
+      players: [
+        {
+          id: "p1",
+          nickname: "A",
+          tableId: "r",
+          seat: 0,
+          chips: 0,
+          isDealer: false,
+          isTurn: false,
+          hand: [
+            { rank: "A", suit: "♠" },
+            { rank: "K", suit: "♦" },
+          ],
+          hasFolded: false,
+          currentBet: 0,
+        },
+        {
+          id: "p2",
+          nickname: "B",
+          tableId: "r",
+          seat: 1,
+          chips: 0,
+          isDealer: false,
+          isTurn: false,
+          hand: [
+            { rank: "Q", suit: "♠" },
+            { rank: "J", suit: "♦" },
+          ],
+          hasFolded: false,
+          currentBet: 0,
+        },
+      ],
+      dealerIndex: 0,
+      currentTurnIndex: 0,
+      stage: "showdown",
+      pot: 0,
+      communityCards: [
+        { rank: "2", suit: "♣" },
+        { rank: "3", suit: "♣" },
+        { rank: "4", suit: "♣" },
+        { rank: "5", suit: "♣" },
+        { rank: "7", suit: "♣" },
+      ],
+      minBet: 0,
+      deck: [],
+    };
+    const winners = determineWinners(room);
+    expect(winners).toHaveLength(1);
+    expect(winners[0].id).toBe("p1");
+  });
+});
+

--- a/packages/nextjs/game/room.ts
+++ b/packages/nextjs/game/room.ts
@@ -1,0 +1,173 @@
+import { GameRoom, PlayerSession, Stage } from "./types";
+import { dealDeck, draw, rankHand, compareHands } from "./utils";
+
+/** Create an empty game room */
+export function createRoom(id: string, minBet = 10): GameRoom {
+  return {
+    id,
+    players: [],
+    dealerIndex: 0,
+    currentTurnIndex: 0,
+    stage: "waiting",
+    pot: 0,
+    communityCards: [],
+    minBet,
+    deck: [],
+  };
+}
+
+/** Add a player to an existing room */
+export function addPlayer(
+  room: GameRoom,
+  player: Omit<
+    PlayerSession,
+    "isDealer" | "isTurn" | "hand" | "hasFolded" | "currentBet" | "tableId"
+  >,
+): PlayerSession {
+  const session: PlayerSession = {
+    ...player,
+    tableId: room.id,
+    isDealer: false,
+    isTurn: false,
+    hand: [],
+    hasFolded: false,
+    currentBet: 0,
+  };
+  room.players.push(session);
+  return session;
+}
+
+/** Start a new hand and deal cards */
+export function startHand(room: GameRoom) {
+  room.deck = dealDeck();
+  room.communityCards = [];
+  room.pot = 0;
+  // rotate dealer (random on first hand)
+  if (room.players.length === 0) return;
+  if (room.stage === "waiting") {
+    room.dealerIndex = Math.floor(Math.random() * room.players.length);
+  } else {
+    room.dealerIndex = (room.dealerIndex + 1) % room.players.length;
+  }
+
+  room.stage = "preflop";
+
+  room.players.forEach((p) => {
+    p.hand = [draw(room.deck), draw(room.deck)];
+    p.hasFolded = false;
+    p.currentBet = 0;
+    p.isDealer = false;
+    p.isTurn = false;
+  });
+  room.players[room.dealerIndex].isDealer = true;
+  room.currentTurnIndex = (room.dealerIndex + 1) % room.players.length;
+  room.players[room.currentTurnIndex].isTurn = true;
+}
+
+function maxBet(room: GameRoom): number {
+  return Math.max(0, ...room.players.map((p) => p.currentBet));
+}
+
+/** Handle a player's betting action */
+export function handleAction(
+  room: GameRoom,
+  playerId: string,
+  action: { type: "fold" | "call" | "raise" | "check"; amount?: number },
+) {
+  const idx = room.players.findIndex((p) => p.id === playerId);
+  if (idx === -1) throw new Error("player not found");
+  const player = room.players[idx];
+  player.isTurn = false;
+
+  const currentMax = maxBet(room);
+
+  switch (action.type) {
+    case "fold":
+      player.hasFolded = true;
+      break;
+    case "call": {
+      const toCall = currentMax - player.currentBet;
+      const callAmt = Math.min(toCall, player.chips);
+      player.chips -= callAmt;
+      player.currentBet += callAmt;
+      room.pot += callAmt;
+      break;
+    }
+    case "raise": {
+      const raiseAmt = action.amount ?? 0;
+      if (raiseAmt <= 0) throw new Error("raise must be > 0");
+      player.chips -= raiseAmt;
+      player.currentBet += raiseAmt;
+      room.pot += raiseAmt;
+      room.minBet = player.currentBet;
+      break;
+    }
+    case "check":
+      if (player.currentBet !== currentMax)
+        throw new Error("cannot check when behind on bets");
+      break;
+  }
+
+  nextTurn(room);
+}
+
+/** Advance turn to the next active player */
+export function nextTurn(room: GameRoom) {
+  if (room.players.length === 0) return;
+  let next = room.currentTurnIndex;
+  do {
+    next = (next + 1) % room.players.length;
+  } while (room.players[next].hasFolded);
+  room.currentTurnIndex = next;
+  room.players.forEach((p, i) => (p.isTurn = i === room.currentTurnIndex));
+}
+
+/** Progress to the next betting street and deal community cards */
+export function progressStage(room: GameRoom) {
+  const order: Stage[] = [
+    "waiting",
+    "preflop",
+    "flop",
+    "turn",
+    "river",
+    "showdown",
+  ];
+  const pos = order.indexOf(room.stage);
+  if (pos === -1 || pos === order.length - 1) return;
+  const next = order[pos + 1];
+
+  // burn card
+  if (room.deck.length) draw(room.deck);
+  if (next === "flop") {
+    room.communityCards.push(draw(room.deck), draw(room.deck), draw(room.deck));
+  } else if (next === "turn" || next === "river") {
+    room.communityCards.push(draw(room.deck));
+  }
+
+  room.players.forEach((p) => (p.currentBet = 0));
+  room.stage = next;
+  room.currentTurnIndex = (room.dealerIndex + 1) % room.players.length;
+  room.players.forEach((p, i) => (p.isTurn = i === room.currentTurnIndex));
+}
+
+/** Determine the winners of the current room */
+export function determineWinners(room: GameRoom): PlayerSession[] {
+  const live = room.players.filter(
+    (p) => !p.hasFolded && p.hand.length === 2,
+  );
+  if (live.length === 0) return [];
+  const evaluated = live.map((p) => ({
+    player: p,
+    score: rankHand([...p.hand, ...room.communityCards]),
+  }));
+  const best = Math.min(...evaluated.map((e) => e.score.rankValue));
+  return evaluated
+    .filter((e) => e.score.rankValue === best)
+    .sort((a, b) => compareHands(a.score, b.score))
+    .reduce<PlayerSession[]>((acc, cur, idx, arr) => {
+      if (idx === 0) return [cur.player];
+      if (compareHands(cur.score, arr[0].score) === 0) acc.push(cur.player);
+      return acc;
+    }, []);
+}
+

--- a/packages/nextjs/game/types.ts
+++ b/packages/nextjs/game/types.ts
@@ -22,6 +22,43 @@ export interface Card {
   rank: Rank;
 }
 
+export type Stage =
+  | "waiting"
+  | "preflop"
+  | "flop"
+  | "turn"
+  | "river"
+  | "showdown";
+
+/** Basic representation of a connected player */
+export interface PlayerSession {
+  id: string; // socket id or UUID
+  nickname: string;
+  tableId: string;
+  seat: number;
+  chips: number;
+  isDealer: boolean;
+  isTurn: boolean;
+  hand: Card[]; // two cards once dealt
+  hasFolded: boolean;
+  /** amount currently wagered in this betting round */
+  currentBet: number;
+}
+
+/** High level room state used by the server */
+export interface GameRoom {
+  id: string;
+  players: PlayerSession[];
+  dealerIndex: number;
+  currentTurnIndex: number;
+  stage: Stage;
+  pot: number;
+  communityCards: Card[];
+  minBet: number;
+  /** remaining cards in the deck */
+  deck: Card[];
+}
+
 export interface Player {
   name: string; // e.g. the player's address or nickname
   chips: number; // how many chips they have (for display)

--- a/packages/nextjs/game/utils.ts
+++ b/packages/nextjs/game/utils.ts
@@ -10,6 +10,9 @@ export function freshDeck(): Card[] {
   return shuffle(deck);
 }
 
+/** Convenience alias used by higher level room logic */
+export const dealDeck = freshDeck;
+
 /** Fisher-Yates in-place shuffle (returns same ref for convenience) */
 export function shuffle<T>(array: T[]): T[] {
   for (let i = array.length - 1; i > 0; i--) {


### PR DESCRIPTION
## Summary
- define session, room and stage types for poker flow
- expose `dealDeck` alias and add room engine for bets/turns/winners
- add unit tests for deck generation, turn skipping and showdown

## Testing
- `yarn next:lint` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_68942b9f0a3c83248a72514ace0d47ce