### PR TITLE
feat: responsive poker table and auto-start

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -16,7 +16,10 @@ export const metadata: Metadata = {
 const ScaffoldStarkApp = ({ children }: { children: React.ReactNode }) => {
   return (
     <html suppressHydrationWarning>
-      <body suppressHydrationWarning className="flex flex-col min-h-screen">
+      <body
+        suppressHydrationWarning
+        className="flex flex-col min-h-screen bg-main"
+      >
         <ThemeProvider>
           <ScaffoldStarkAppWithProviders>
             {children}

--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -14,7 +14,7 @@ export default function PlayPage() {
 
   return (
     <main
-      className="min-h-screen flex flex-col text-white bg-cover bg-center"
+      className="min-h-screen flex flex-col text-white bg-main bg-cover bg-center"
       style={{ backgroundImage: `url('/nfts/nft2.png')` }}
     >
       <header className="relative w-full max-w-6xl flex justify-between items-center mt-6 mb-4 px-4">

--- a/packages/nextjs/components/HowItWorksSection.tsx
+++ b/packages/nextjs/components/HowItWorksSection.tsx
@@ -51,7 +51,7 @@ export default function HowItWorksSection() {
   return (
     <section
       id="how"
-      className="bg-gradient-to-b from-gray-900 via-black to-gray-900 text-white py-24"
+      className="py-24 bg-white text-black dark:bg-gray-900 dark:text-white"
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-12">
         <h2 className="text-3xl sm:text-4xl font-bold text-center mb-16">
@@ -61,13 +61,13 @@ export default function HowItWorksSection() {
           {steps.map(({ title, description, icon: Icon }, index) => (
             <div
               key={index}
-              className="relative p-6 rounded-xl bg-gray-900/60 border border-gray-800 shadow-center transition-transform hover:-translate-y-1 hover:shadow-neon"
+              className="relative p-6 rounded-xl bg-white/70 border border-gray-200 shadow-center transition-transform hover:-translate-y-1 hover:shadow-neon dark:bg-gray-900/60 dark:border-gray-800"
             >
               <div className="flex items-center justify-center w-12 h-12 mb-4 rounded-full bg-accent/20 text-accent text-xl">
                 <Icon />
               </div>
               <h3 className="text-xl font-semibold mb-2">{title}</h3>
-              <p className="text-gray-300 text-sm">{description}</p>
+              <p className="text-gray-700 text-sm dark:text-gray-300">{description}</p>
             </div>
           ))}
         </div>

--- a/packages/nextjs/components/MissionStatementSection.tsx
+++ b/packages/nextjs/components/MissionStatementSection.tsx
@@ -5,7 +5,9 @@ const message =
 
 export default function MissionStatementSection() {
   return (
-    <section className="bg-gradient-to-r from-secondary/20 via-black to-secondary/20 text-white py-6 overflow-hidden">
+    <section
+      className="py-6 overflow-hidden bg-white text-black dark:bg-gradient-to-r dark:from-secondary/20 dark:via-black dark:to-secondary/20 dark:text-white"
+    >
       <div className="whitespace-nowrap">
         <div className="animate-marquee inline-block text-lg tracking-wide">
           <span className="mx-8">{message}</span>

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -1,53 +1,76 @@
 // src/components/Table.tsx
 
+import { useEffect, useState } from "react";
 import { useGameStore } from "../hooks/useGameStore";
 import Card from "./Card";
 import { indexToCard } from "../game/utils";
 import PlayerSeat from "./PlayerSeat";
 import type { Player } from "../game/types";
 
+interface SeatPos {
+  x: string;
+  y: string;
+  t: string;
+  r: number;
+}
+
 /* ─── absolute positions (0 = top, 4 = bottom-center) ─── */
-const seatLayout = [
-  { x: "72%", y: "1%", t: "-50%,-50%" }, // 1 top-right
-  { x: "96%", y: "20%", t: "-50%,-50%" }, // 2 right-top
-  { x: "100%", y: "60%", t: "-50%,-50%" }, // 3 right
-  { x: "82%", y: "90%", t: "-50%,-50%" }, // 4 bottom-right
-  { x: "50%", y: "100%", t: "-50%,-100%" }, // 5 bottom (local)
-  { x: "18%", y: "90%", t: "-50%,-50%" }, // 6 bottom-left
-  { x: "0%", y: "60%", t: "-50%,-50%" }, // 7 left
-  { x: "4%", y: "20%", t: "-50%,-50%" }, // 8 left-top
-  { x: "28%", y: "1%", t: "-50%,-50%" }, // 9 top-left
+const desktopLayout: SeatPos[] = [
+  { x: "72%", y: "1%", t: "-50%,-50%", r: 0 }, // 1 top-right
+  { x: "96%", y: "20%", t: "-50%,-50%", r: 0 }, // 2 right-top
+  { x: "100%", y: "60%", t: "-50%,-50%", r: 0 }, // 3 right
+  { x: "82%", y: "90%", t: "-50%,-50%", r: 0 }, // 4 bottom-right
+  { x: "50%", y: "100%", t: "-50%,-100%", r: 0 }, // 5 bottom (local)
+  { x: "18%", y: "90%", t: "-50%,-50%", r: 0 }, // 6 bottom-left
+];
+
+const mobileLayout: SeatPos[] = [
+  { x: "50%", y: "4%", t: "-50%,-50%", r: 180 }, // top
+  { x: "88%", y: "20%", t: "-50%,-50%", r: 90 }, // right-top
+  { x: "88%", y: "80%", t: "-50%,-50%", r: 90 }, // right-bottom
+  { x: "50%", y: "96%", t: "-50%,-50%", r: 0 }, // bottom
+  { x: "12%", y: "80%", t: "-50%,-50%", r: -90 }, // left-bottom
+  { x: "12%", y: "20%", t: "-50%,-50%", r: -90 }, // left-top
 ];
 
 /* ─────────────────────────────────────────────────────── */
 
 export default function Table() {
-  const { players, community } = useGameStore();
+  const { players, community, joinSeat } = useGameStore();
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handle = () => setIsMobile(window.innerWidth < 640);
+    handle();
+    window.addEventListener("resize", handle);
+    return () => window.removeEventListener("resize", handle);
+  }, []);
+
+  const layout = isMobile ? mobileLayout : desktopLayout;
 
   /* helper – render a seat or an empty placeholder */
   const seatAt = (idx: number) => {
     const address = players[idx];
-    const style = {
-      left: seatLayout[idx].x,
-      top: seatLayout[idx].y,
-      transform: `translate(${seatLayout[idx].t})`,
+    const pos = layout[idx];
+    if (!pos) return null;
+    const posStyle = {
+      left: pos.x,
+      top: pos.y,
+      transform: `translate(${pos.t})`,
     } as React.CSSProperties;
 
     /* ── empty seat → button ─────────────────────────────── */
     if (!address) {
       return (
-        <button
-          key={idx}
-          style={style}
-          onClick={() => alert("Sit-down logic TBD")}
-          className="
-          absolute w-24 h-8 flex items-center justify-center rounded
-          text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20
-          transition-colors duration-150 hover:bg-red-500 hover:text-white
-        "
-        >
-          Join Seat
-        </button>
+        <div key={idx} style={posStyle} className="absolute">
+          <button
+            onClick={() => joinSeat(idx)}
+            style={{ transform: `rotate(${pos.r}deg)` }}
+            className="w-24 h-8 flex items-center justify-center rounded text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20 transition-colors duration-150 hover:bg-red-500 hover:text-white"
+          >
+            Join Seat
+          </button>
+        </div>
       );
     }
 
@@ -64,14 +87,16 @@ export default function Table() {
     const reveal = idx === 4; // local player
 
     return (
-      <div key={idx} style={style} className="absolute">
-        <PlayerSeat
-          player={player}
-          isDealer={isDealer}
-          isActive={isActive}
-          revealCards={reveal}
-          bet={player.currentBet}
-        />
+      <div key={idx} style={posStyle} className="absolute">
+        <div style={{ transform: `rotate(${pos.r}deg)` }}>
+          <PlayerSeat
+            player={player}
+            isDealer={isDealer}
+            isActive={isActive}
+            revealCards={reveal}
+            bet={player.currentBet}
+          />
+        </div>
       </div>
     );
   };
@@ -93,18 +118,14 @@ export default function Table() {
   );
 
   return (
-    <div className="relative flex justify-center items-center py-24">
+    <div className="relative flex justify-center items-center py-24 bg-main">
       {/* poker-table oval */}
       <div
-        className="
-          relative rounded-full border-8 border-[var(--brand-accent)] bg-gradient-to-br from-[#1e1e1e] to-[#0e0e0e]
-          shadow-[0_0_40px_rgba(0,0,0,0.6)]
-          w-[680px] h-[420px]
-        "
+        className="relative rounded-full border-8 border-[var(--brand-accent)] bg-gradient-to-br from-[#1e1e1e] to-[#0e0e0e] shadow-[0_0_40px_rgba(0,0,0,0.6)] md:w-[680px] md:h-[420px] w-[420px] h-[680px]"
       >
         {communityRow}
         {/* seats */}
-        {seatLayout.map((_, i) => seatAt(i))}
+        {layout.map((_, i) => seatAt(i))}
       </div>
     </div>
   );

--- a/packages/nextjs/hooks/useGameStore.ts
+++ b/packages/nextjs/hooks/useGameStore.ts
@@ -82,6 +82,11 @@ export const useGameStore = create<GameState>((set, get) => ({
       // invoke("take_seat", [seat_idx])
       await table.invoke("take_seat", [BigInt(seatIdx)]);
       await get().reloadTableState();
+      const count = get().players.filter((p) => p).length;
+      set({ loading: false });
+      if (count >= 2) {
+        await get().startHand();
+      }
     } catch (err: any) {
       console.error(err);
       set({ error: "Failed to join seat", loading: false });


### PR DESCRIPTION
## Summary
- use themed global backgrounds across pages and sections
- support light and dark backgrounds for content sections
- make poker table responsive with vertical mobile layout and join-seat logic
- auto-start game once two players have seated

## Testing
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn next:lint` *(fails: The project in package.json doesn't seem to have been installed)*

------
https://chatgpt.com/codex/tasks/task_e_6894401f321883249e255c594cf082e6