### PR TITLE
feat: add whitelist and gated NFT minting pages

### DIFF
--- a/packages/nextjs/app/nft/mint/page.tsx
+++ b/packages/nextjs/app/nft/mint/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { useState } from "react";
+import { useAccount } from "@starknet-react/core";
+import Button from "~~/components/ui/Button";
+import { WHITELISTED_ADDRESSES } from "~~/constants";
+
+const MintPage: React.FC = () => {
+  const { address } = useAccount();
+  const [form, setForm] = useState({
+    title: "",
+    image: "",
+    description: "",
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Mint data", form);
+  };
+
+  if (!address || !WHITELISTED_ADDRESSES.includes(address.toLowerCase())) {
+    return (
+      <main className="p-6 text-center">
+        <p>Your wallet is not whitelisted for minting.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-6 max-w-md mx-auto space-y-4">
+      <h1 className="text-2xl font-semibold text-center">Mint NFT</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+          placeholder="Title"
+          className="w-full p-2 rounded-md bg-transparent border border-border text-background"
+        />
+        <input
+          name="image"
+          value={form.image}
+          onChange={handleChange}
+          placeholder="Image URL"
+          className="w-full p-2 rounded-md bg-transparent border border-border text-background"
+        />
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          placeholder="Description"
+          className="w-full p-2 rounded-md bg-transparent border border-border text-background"
+        />
+        <Button type="submit" className="w-full">
+          Mint NFT
+        </Button>
+      </form>
+    </main>
+  );
+};
+
+export default MintPage;

--- a/packages/nextjs/app/whitelist/page.tsx
+++ b/packages/nextjs/app/whitelist/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React, { useState } from "react";
+import Button from "~~/components/ui/Button";
+
+const WhitelistPage: React.FC = () => {
+  const [form, setForm] = useState({ address: "", email: "" });
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <main className="p-6 max-w-md mx-auto space-y-4">
+      <h1 className="text-2xl font-semibold text-center">
+        Whitelist Application
+      </h1>
+      {submitted ? (
+        <p className="text-center">Thanks for applying! We'll be in touch.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            name="address"
+            value={form.address}
+            onChange={handleChange}
+            placeholder="Wallet Address"
+            required
+            className="w-full p-2 rounded-md bg-transparent border border-border text-background"
+          />
+          <input
+            name="email"
+            type="email"
+            value={form.email}
+            onChange={handleChange}
+            placeholder="Email"
+            className="w-full p-2 rounded-md bg-transparent border border-border text-background"
+          />
+          <Button type="submit" className="w-full">
+            Apply
+          </Button>
+        </form>
+      )}
+    </main>
+  );
+};
+
+export default WhitelistPage;

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -25,6 +25,8 @@ export const menuLinks: HeaderMenuLink[] = [
   { label: "How it Works", href: "/#how" },
   { label: "Top Tournaments", href: "/#tournaments" },
   { label: "Marketplace", href: "/#marketplace" },
+  { label: "Whitelist", href: "/whitelist" },
+  { label: "Mint", href: "/nft/mint" },
 ];
 
 export const HeaderMenuLinks = () => {

--- a/packages/nextjs/constants.ts
+++ b/packages/nextjs/constants.ts
@@ -5,3 +5,7 @@ export const DECK_SHUFFLER_ADDRESS = "0x...";
 export const NFT_TICKET_ABI = "/src/abi/NFTTicket_abi.json";
 export const TABLE_STATE_ABI = "/src/abi/TableState_abi.json";
 export const DECK_SHUFFLER_ABI = "/src/abi/DeckShuffler_abi.json";
+export const WHITELISTED_ADDRESSES = [
+  "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+];


### PR DESCRIPTION
## Summary
- add whitelist application page
- gate NFT minting page to approved wallet addresses
- expose whitelist and mint links in header

## Testing
- `yarn workspace @ss-2/nextjs lint` *(fails: TypeError: Cannot convert undefined or null to object)*
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*


------
https://chatgpt.com/codex/tasks/task_e_689440e44e08832489edffa4b519dcbc