### PR TITLE
feat: add websocket server for multiplayer

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -12,7 +12,8 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "postinstall": "shx cp -n .env.example .env",
-    "vercel": "vercel"
+    "vercel": "vercel",
+    "ws-server": "ts-node server/index.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",
@@ -49,6 +50,7 @@
     "starknet": "^7.1.0",
     "type-fest": "^4.6.0",
     "usehooks-ts": "^2.13.0",
+    "ws": "^8.18.3",
     "zustand": "^4.1.2"
   },
   "devDependencies": {
@@ -61,6 +63,7 @@
     "@types/react": "18.2.48",
     "@types/react-copy-to-clipboard": "^5.0.4",
     "@types/react-dom": "18.2.19",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-istanbul": "^2.1.1",
     "@vitest/coverage-v8": "^2.1.1",
@@ -71,6 +74,7 @@
     "postcss": "^8",
     "shx": "^0.4.0",
     "tailwindcss": "^3.3.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5",
     "vercel": "^33.7.1",
     "vite": "^6.2.3",

--- a/packages/nextjs/server/index.ts
+++ b/packages/nextjs/server/index.ts
@@ -1,0 +1,75 @@
+import { WebSocketServer, WebSocket } from "ws";
+import { createRoom, addPlayer, handleAction, startHand } from "../game/room";
+import type { GameRoom } from "../game/types";
+
+function shortAddress(addr: string): string {
+  if (addr.length <= 8) return addr;
+  return `${addr.slice(0, 4)}..${addr.slice(-4)}`;
+}
+
+const wss = new WebSocketServer({ port: 8080 });
+const room: GameRoom = createRoom("default");
+const clients = new Map<WebSocket, string>();
+
+function broadcast(data: unknown) {
+  const msg = JSON.stringify(data);
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) client.send(msg);
+  });
+}
+
+wss.on("connection", (ws) => {
+  ws.on("message", (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      switch (msg.type) {
+        case "join": {
+          const address: string = msg.address;
+          const id = address;
+          const nickname = shortAddress(address);
+          addPlayer(room, {
+            id,
+            nickname,
+            seat: room.players.length,
+            chips: 1000,
+          });
+          clients.set(ws, id);
+          broadcast({
+            type: "players",
+            players: room.players.map((p) => ({
+              id: p.id,
+              nickname: p.nickname,
+            })),
+          });
+          break;
+        }
+        case "start": {
+          startHand(room);
+          broadcast({ type: "state", room });
+          break;
+        }
+        case "action": {
+          handleAction(room, msg.playerId, msg.action);
+          broadcast({ type: "state", room });
+          break;
+        }
+      }
+    } catch (err) {
+      console.error("invalid message", err);
+    }
+  });
+
+  ws.on("close", () => {
+    const id = clients.get(ws);
+    if (!id) return;
+    const idx = room.players.findIndex((p) => p.id === id);
+    if (idx !== -1) room.players.splice(idx, 1);
+    clients.delete(ws);
+    broadcast({
+      type: "players",
+      players: room.players.map((p) => ({ id: p.id, nickname: p.nickname })),
+    });
+  });
+});
+
+console.log("WebSocket server running on ws://localhost:8080");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,6 +3775,7 @@ __metadata:
     "@types/react": 18.2.48
     "@types/react-copy-to-clipboard": ^5.0.4
     "@types/react-dom": 18.2.19
+    "@types/ws": ^8.18.1
     "@vitejs/plugin-react": ^4.3.4
     "@vitest/coverage-istanbul": ^2.1.1
     "@vitest/coverage-v8": ^2.1.1
@@ -3804,6 +3805,7 @@ __metadata:
     shx: ^0.4.0
     starknet: ^7.1.0
     tailwindcss: ^3.3.0
+    ts-node: ^10.9.2
     type-fest: ^4.6.0
     typescript: ^5
     usehooks-ts: ^2.13.0
@@ -3812,6 +3814,7 @@ __metadata:
     vitest: ^3.0.9
     webpack: ^5.97.1
     webpack-cli: ^6.0.1
+    ws: ^8.18.3
     zustand: ^4.1.2
   peerDependencies:
     "@babel/core": ^7.0.0
@@ -4337,6 +4340,15 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 0331b14cde388e2805af66cad3e3f51857db8e68ed91e5b99750915e96fe7572e58296dc99999331bbcf08f0ff00a227a0bb214e991f53c2a5aca7b0e71173fa
   languageName: node
   linkType: hard
 
@@ -14444,7 +14456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0":
+"ws@npm:^8.18.0, ws@npm:^8.18.3":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:


### PR DESCRIPTION
## Summary
- add a minimal WebSocket server that uses Starknet addresses as nicknames and syncs game state
- expose a `ws-server` script and dependencies for running the server

## Testing
- `yarn workspace @ss-2/nextjs lint` *(fails: TypeError: Cannot convert undefined or null to object)*
- `yarn workspace @ss-2/nextjs check-types` *(fails: JSX element implicitly has type 'any')*
- `yarn workspace @ss-2/nextjs format:check` *(fails: Code style issues found in 8 files)*
- `yarn workspace @ss-2/nextjs test` *(fails: vite tried to access #module-sync-enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68944c1c7f38832486f93811bf48b2cc