### PR TITLE
fix: improve wallet modal readability

### DIFF
--- a/packages/nextjs/components/ui/WalletModal.tsx
+++ b/packages/nextjs/components/ui/WalletModal.tsx
@@ -15,12 +15,12 @@ export const WalletModal: React.FC = () => {
           <div className="bg-primary p-6 rounded-md w-80">
             {connected ? (
               <div className="space-y-4">
-                <p className="text-background">0x1234...abcd</p>
+                <p>0x1234...abcd</p>
                 <Button onClick={() => setConnected(false)}>Disconnect</Button>
               </div>
             ) : (
               <div className="space-y-4">
-                <p className="text-background">Connect your wallet</p>
+                <p>Connect your wallet</p>
                 <Button onClick={() => setConnected(true)}>Connect</Button>
               </div>
             )}


### PR DESCRIPTION
## Summary
- remove background text color from wallet modal

## Testing
- `yarn install` (failed: unrs-resolver build error)
- `yarn next:lint` (failed: Next telemetry storage error)
- `yarn next:check-types` (failed: Next telemetry storage error)
- `yarn test:nextjs` (failed: Next telemetry storage error)

------
https://chatgpt.com/codex/tasks/task_e_689452ec8fa48324906879e101d3351f