### PR TITLE
fix: add version for nextjs workspace

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ss-2/nextjs",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary
- specify version in Next.js package to satisfy workspace requirements during builds

## Testing
- `yarn build` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*


------
https://chatgpt.com/codex/tasks/task_e_6894574c2c2883249478855db6b3051e