### PR TITLE
chore: include minimatch types for nextjs

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -58,6 +58,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "@types/minimatch": "^5.1.2",
     "@types/next-pwa": "^5",
     "@types/node": "^20",
     "@types/nprogress": "^0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,6 +3769,7 @@ __metadata:
     "@testing-library/dom": ^10.4.0
     "@testing-library/jest-dom": ^6.6.3
     "@testing-library/react": ^16.2.0
+    "@types/minimatch": ^5.1.2
     "@types/next-pwa": ^5
     "@types/node": ^20
     "@types/nprogress": ^0
@@ -4198,7 +4199,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/minimatch@npm:*":
+"@types/minimatch@npm:*, @types/minimatch@npm:^5.1.2":
   version: 5.1.2
   resolution: "@types/minimatch@npm:5.1.2"
   checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8


### PR DESCRIPTION
## Summary
- add `@types/minimatch` to Next.js workspace to satisfy implicit type dependency

## Testing
- `yarn next:check-types` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `cd packages/nextjs && yarn check-types` *(fails: cannot find module 'abi-wan-kanabi/dist/kanabi' and other type resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894726f49fc83249f69ea15165feec7