### PR TITLE
style: use neon accent background for modals

### DIFF
--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -113,9 +113,9 @@ const ConnectModal = () => {
                         className="w-full flex flex-col"
                       >
                         <button
-                          className={`hover:bg-gradient-modal border rounded-md text-neutral py-[8px] pl-[10px] pr-16 flex items-center gap-4 ${
-                            isDarkMode ? "border-[#385183]" : ""
-                          }`}
+                        className={`hover:bg-gradient-modal border rounded-md text-black py-[8px] pl-[10px] pr-16 flex items-center gap-4 ${
+                          isDarkMode ? "border-[#385183]" : ""
+                        }`}
                           onClick={(e) => handleConnectBurner(e, ix)}
                         >
                           <BlockieAvatar

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/GenericModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/GenericModal.tsx
@@ -1,16 +1,12 @@
-import { useTheme } from "next-themes";
-
 const GenericModal = ({
   children,
-  className = "modal-box modal-border rounded-[8px] border flex flex-col gap-3 justify-around relative",
+  className = "modal-box modal-border rounded-[8px] border flex flex-col gap-3 justify-around relative bg-[var(--color-accent)] text-black",
   modalId,
 }: {
   children: React.ReactNode;
   className?: string;
   modalId: string;
 }) => {
-  const { resolvedTheme } = useTheme();
-  const isDarkMode = resolvedTheme === "dark";
   return (
     <label htmlFor={modalId} className="modal  backdrop-blur cursor-pointer">
       <label className={className}>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/Wallet.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/Wallet.tsx
@@ -34,7 +34,7 @@ const Wallet = ({
 
   return isMounted ? (
     <button
-      className={`flex gap-4 items-center text-neutral  rounded-[4px] p-3 transition-all ${
+      className={`flex gap-4 items-center text-black  rounded-[4px] p-3 transition-all ${
         isDarkMode
           ? "hover:bg-[#385183] border-[#4f4ab7]"
           : "hover:bg-slate-200 border-[#5c4fe5]"


### PR DESCRIPTION
## Summary
- style GenericModal with neon accent background and black text
- use black text for ConnectModal burner account options
- ensure wallet connector entries display black text

## Testing
- `yarn format:check` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn next:lint` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn next:check-types` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*


------
https://chatgpt.com/codex/tasks/task_e_6894a37503ac83248d0ce356ce3419b8