### PR TITLE
chore: add starknet env examples

### DIFF
--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -1,12 +1,12 @@
-NEXT_PUBLIC_PROVIDER_URL=http://127.0.0.1:5050  
+NEXT_PUBLIC_PROVIDER_URL=http://127.0.0.1:5050
 
 # URL Devnet
 NEXT_PUBLIC_DEVNET_PROVIDER_URL=http://127.0.0.1:5050
 
 # URL Sepolia
-# NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.blastapi.io/64168c77-3fa5-4e1e-9fe4-41675d212522/rpc/v0_8
+NEXT_PUBLIC_SEPOLIA_PROVIDER_URL=https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_8/YOUR_API_KEY/rpc
 
 # URL Mainnet
-# NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.blastapi.io/64168c77-3fa5-4e1e-9fe4-41675d212522/rpc/v0_8
+NEXT_PUBLIC_MAINNET_PROVIDER_URL=https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_8/YOUR_API_KEY/rpc
 
 

--- a/packages/snfoundry/.env.example
+++ b/packages/snfoundry/.env.example
@@ -8,9 +8,9 @@
 
 ## Sepolia 
 # Below input your testnet private key
-PRIVATE_KEY_SEPOLIA= 
+PRIVATE_KEY_SEPOLIA=
 # Below input the rpc url of the testnet network
-RPC_URL_SEPOLIA=https://starknet-sepolia.public.blastapi.io/rpc/v0_8
+RPC_URL_SEPOLIA=https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_8/YOUR_API_KEY/rpc
 # Below input your testnet account address
 ACCOUNT_ADDRESS_SEPOLIA=
 
@@ -18,6 +18,6 @@ ACCOUNT_ADDRESS_SEPOLIA=
 # Below input your mainnet private key
 PRIVATE_KEY_MAINNET=
 # Below input the rpc url of the mainnet network
-RPC_URL_MAINNET=https://starknet-mainnet.public.blastapi.io/rpc/v0_8
+RPC_URL_MAINNET=https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_8/YOUR_API_KEY/rpc
 # Below input your mainnet account address
 ACCOUNT_ADDRESS_MAINNET=


### PR DESCRIPTION
## Summary
- add Alchemy Starknet Sepolia and Mainnet provider URLs to Next.js env example
- update snfoundry env example with matching Alchemy URLs

## Testing
- `yarn format:check` *(fails: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn install` *(fails: unrs-resolver couldn't be built)*

------
https://chatgpt.com/codex/tasks/task_e_6894b2a4b2e8832480f930680b85770e