### PR TITLE
Initialize Starknet provider on wallet connect

### DIFF
--- a/packages/nextjs/components/scaffold-stark/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-stark/Input/AddressInput.tsx
@@ -21,6 +21,7 @@ export const AddressInput = ({
 
   const handleChange = useCallback(
     (newValue: Address) => {
+      if (!newValue) return;
       const sanitizedValue = newValue.toLowerCase();
 
       if (sanitizedValue === "0x") {

--- a/packages/nextjs/hooks/useAccount.ts
+++ b/packages/nextjs/hooks/useAccount.ts
@@ -4,6 +4,7 @@ import {
 } from "@starknet-react/core";
 import { useEffect, useState, useMemo } from "react";
 import { AccountInterface, constants } from "starknet";
+import { initStarknet } from "~~/services/starknet";
 
 /**
  * Wrapper around starknet react's useAccount hook to fix inconsistencies
@@ -23,6 +24,8 @@ export function useAccount(): UseAccountResult {
 
   useEffect(() => {
     if (account) {
+      // ensure Starknet provider and account are initialised once a wallet connects
+      initStarknet({ account });
       const getChainId = async () => {
         try {
           let chainId: string | bigint;


### PR DESCRIPTION
## Summary
- initialize Starknet provider/account once wallet connects
- guard against undefined values in address input field

## Testing
- `yarn next:lint` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_6894c0d9d0ac83249a024db364002db2