### PR TITLE
Improve mobile table spacing and full-screen play page

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -14,7 +14,7 @@ export default function PlayPage() {
 
   return (
     <main
-      className="min-h-screen flex flex-col text-white bg-main bg-cover bg-center"
+      className="h-screen flex flex-col text-white bg-main bg-cover bg-center overflow-hidden"
       style={{ backgroundImage: `url('/nfts/nft2.png')` }}
     >
       <header className="relative w-full max-w-6xl flex justify-between items-center mt-6 mb-4 px-4">
@@ -32,7 +32,9 @@ export default function PlayPage() {
           <CustomConnectButton />
         </div>
       </header>
-      <Table />
+      <div className="flex-1 flex items-center justify-center">
+        <Table />
+      </div>
     </main>
   );
 }

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -23,7 +23,11 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
   const cy = isMobile ? 54 : 50;
   const step = (2 * Math.PI) / count;
   return Array.from({ length: count }).map((_, i) => {
-    const angle = step * (i + 0.5) - Math.PI / 2; // leave gap at top for bank
+    let angle = step * (i + 0.5) - Math.PI / 2; // leave gap at top for bank
+    if (isMobile) {
+      const adjustments = [20, 0, -10, 10, 0, -10, 10, 0, -20];
+      angle += (adjustments[i] * Math.PI) / 180;
+    }
     return {
       x: `${50 + rx * Math.cos(angle)}%`,
       y: `${cy + ry * Math.sin(angle)}%`,
@@ -142,7 +146,7 @@ export default function Table() {
             community[i] !== null ? indexToCard(community[i] as number) : null
           }
           hidden={community[i] === null}
-          size="md"
+          size={tableScale < 1 ? "sm" : "md"}
         />
       ))}
     </div>
@@ -152,7 +156,7 @@ export default function Table() {
   const baseH = isMobile ? 680 : 520;
 
   return (
-    <div className="relative flex justify-center items-center py-24">
+    <div className="relative flex justify-center items-center w-full h-full">
       {/* poker-table oval */}
       <div
         className="relative rounded-full border-8 border-[var(--brand-accent)] bg-main shadow-[0_0_40px_rgba(0,0,0,0.6)]"


### PR DESCRIPTION
## Summary
- Ensure play page fills viewport with stretchable background image
- Adjust mobile table layout to space out top and middle seats
- Scale community cards down on smaller tables

## Testing
- `yarn format` *(failed: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn next:lint` *(failed: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn test:nextjs` *(failed: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_6894c43b4abc8324bd51221ad58fc32d