### PR TITLE
fix: center play background and add seat numbers

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -14,14 +14,17 @@ export default function PlayPage() {
 
   return (
     <main
-      className="h-screen flex flex-col text-white bg-main bg-cover bg-center overflow-hidden"
-      style={{ backgroundImage: `url('/nfts/nft2.png')` }}
+      className="h-screen flex flex-col text-white bg-main overflow-hidden"
+      style={{
+        backgroundImage: "url('/nfts/nft2.png')",
+        backgroundSize: "auto 100%",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+      }}
     >
-      <header className="relative w-full max-w-6xl flex justify-between items-center mt-6 mb-4 px-4">
-        <div className="flex-1">
-          <h1 className="text-4xl font-bold text-left">Poker Night on Starknet</h1>
-        </div>
-        <div className="flex items-center gap-4">
+      <header className="relative w-full max-w-6xl flex items-center mt-6 mb-4 px-4">
+        <h1 className="text-4xl font-bold text-left">Poker Night on Starknet</h1>
+        <div className="ml-auto flex items-center gap-4">
           <ActionBar
             street={stageNames[street] ?? "preflop"}
             onStart={startHand}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -85,16 +85,25 @@ export default function Table() {
       transform: `translate(${pos.t})`,
     } as React.CSSProperties;
 
+    const seatNumber = (
+      <span className="absolute -top-4 -left-4 w-6 h-6 rounded-full bg-black/60 text-white text-xs flex items-center justify-center">
+        {idx + 1}
+      </span>
+    );
+
     /* ── empty seat → button ─────────────────────────────── */
     if (!address) {
       return (
         <div key={idx} style={posStyle} className="absolute">
-          <button
-            onClick={() => joinSeat(idx)}
-            className="w-24 h-8 flex items-center justify-center rounded text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20 transition-colors duration-150 hover:bg-red-500 hover:text-white"
-          >
-            Play
-          </button>
+          <div className="relative">
+            {seatNumber}
+            <button
+              onClick={() => joinSeat(idx)}
+              className="w-24 h-8 flex items-center justify-center rounded text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20 transition-colors duration-150 hover:bg-red-500 hover:text-white"
+            >
+              Play
+            </button>
+          </div>
         </div>
       );
     }
@@ -113,14 +122,17 @@ export default function Table() {
 
     return (
       <div key={idx} style={posStyle} className="absolute">
-        <div style={{ transform: `rotate(${pos.r}deg)` }}>
-          <PlayerSeat
-            player={player}
-            isDealer={isDealer}
-            isActive={isActive}
-            revealCards={reveal}
-            bet={player.currentBet}
-          />
+        <div className="relative">
+          {seatNumber}
+          <div style={{ transform: `rotate(${pos.r}deg)` }}>
+            <PlayerSeat
+              player={player}
+              isDealer={isDealer}
+              isActive={isActive}
+              revealCards={reveal}
+              bet={player.currentBet}
+            />
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- stretch play page background image to full height and center it
- right-align deal and connect controls
- show numbered markers for each table seat

## Testing
- `yarn test:nextjs` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn next:lint` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_6894c71036f48324abe86f0814fcdc8a