### PR TITLE
style: adjust play page layout

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -18,14 +18,14 @@ export default function PlayPage() {
       className="h-screen flex flex-col text-white bg-main overflow-hidden"
       style={{
         backgroundImage: "url('/nfts/nft2.png')",
-        backgroundSize: "auto 100%",
+        backgroundSize: "cover",
         backgroundPosition: "center",
         backgroundRepeat: "no-repeat",
       }}
     >
-      <header className="relative w-full max-w-6xl flex items-center justify-between mt-6 mb-4 px-4">
+      <header className="relative w-full flex items-center mt-6 mb-4 px-4">
         <AnimatedTitle text="Poker Night on Starknet" />
-        <div className="ml-auto flex items-center gap-4">
+        <div className="flex flex-1 items-center justify-end gap-4">
           <ActionBar
             street={stageNames[street] ?? "preflop"}
             onStart={startHand}


### PR DESCRIPTION
## Summary
- scale play page background image to cover viewport
- align action bar and connect button in a right-justified row

## Testing
- `yarn workspace @ss-2/nextjs eslint app/play/page.tsx` *(fails: Cannot read properties of undefined (reading '/workspace/pokernft/.yarn/__virtual__/eslint-config-next-virtual-a43674c278/0/cache/eslint-config-next-npm-14.2.7-25339e8fd8-db8aafac22.zip/node_modules/eslint-config-next/index.js'))*
- `yarn test:nextjs` *(fails: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_6894d83d62f8832498127049113a9d5d