### PR TITLE
Scale cards to fit table layout

### DIFF
--- a/packages/nextjs/components/Card.tsx
+++ b/packages/nextjs/components/Card.tsx
@@ -51,7 +51,7 @@ function faceKey(card: TCard) {
 interface Props {
   card: TCard | null; // null while face-down
   hidden?: boolean;
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   className?: string;
 }
 
@@ -64,6 +64,7 @@ export default function Card({
   const className = clsx(
     "rounded-md shadow-sm",
     {
+      "w-12 h-18": size === "xs",
       "w-16 h-24": size === "sm",
       "w-20 h-28": size === "md",
       "w-24 h-32": size === "lg",

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -10,6 +10,7 @@ interface PlayerSeatProps {
   isActive?: boolean; // highlight border when it's this player's turn
   bet?: number; // amount currently bet by this player
   revealCards?: boolean; // if true, show hole cards face-up
+  cardSize?: "xs" | "sm" | "md" | "lg"; // size of player's hole cards
 }
 
 export default function PlayerSeat({
@@ -18,6 +19,7 @@ export default function PlayerSeat({
   isActive = false,
   bet = 0,
   revealCards = false,
+  cardSize = "lg",
 }: PlayerSeatProps) {
   // If `player.hand` is null, treat as not yet dealt
   const [hole1, hole2]: [TCard | null, TCard | null] = player.hand ?? [
@@ -42,8 +44,8 @@ export default function PlayerSeat({
 
       {/* Pocket cards positioned above the seat */}
       <div className="absolute -top-24 left-1/2 -translate-x-1/2 flex gap-2">
-        <Card card={hole1} hidden={!revealCards} size="lg" />
-        <Card card={hole2} hidden={!revealCards} size="lg" />
+        <Card card={hole1} hidden={!revealCards} size={cardSize} />
+        <Card card={hole2} hidden={!revealCards} size={cardSize} />
       </div>
 
       {/* Player name and chip count */}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -86,6 +86,14 @@ export default function Table() {
     return max;
   }, [layout]);
 
+  const communityCardSize = useMemo(() => {
+    return tableScale < 0.75 ? "xs" : tableScale < 1 ? "sm" : "md";
+  }, [tableScale]);
+
+  const holeCardSize = useMemo(() => {
+    return tableScale < 0.75 ? "sm" : tableScale < 1 ? "md" : "lg";
+  }, [tableScale]);
+
   /* helper – render a seat or an empty placeholder */
   const seatAt = (idx: number) => {
     const address = players[idx];
@@ -143,6 +151,7 @@ export default function Table() {
               isActive={isActive}
               revealCards={reveal}
               bet={player.currentBet}
+              cardSize={holeCardSize}
             />
           </div>
         </div>
@@ -170,7 +179,7 @@ export default function Table() {
             community[i] !== null ? indexToCard(community[i] as number) : null
           }
           hidden={community[i] === null}
-          size={tableScale < 1 ? "sm" : "md"}
+          size={communityCardSize}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- support extra small card size and scale community cards with table size
- allow player seats to receive dynamic card size
- compute responsive card sizes so community and player cards don't overlap

## Testing
- `yarn test:nextjs` *(fails: Cannot read properties of undefined reading '/workspace/pokernft/.pnp.cjs')*
- `yarn next:lint` *(fails: Cannot read properties of undefined reading '/workspace/pokernft/.pnp.cjs')*

------
https://chatgpt.com/codex/tasks/task_e_6894e2a08e108324b3a9efe7efa6a18f