### PR TITLE
feat(backend): add poker table state machine

### DIFF
--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1,0 +1,33 @@
+# Design Rules and Guidelines
+
+These guidelines describe architectural principles for the poker backend to ensure modularity, maintainability, and future extensibility.
+
+## Modular Architecture
+
+- **Separation of Concerns**: Distinct modules handle networking, game logic, randomness, hand evaluation, and persistence.
+- **Replaceable Components**: Each module communicates through clearly defined interfaces. Implementations (e.g., RNG provider or evaluation library) can be swapped without changing consumers.
+- **State Machine Core**: The game engine exposes a state machine (see `game-states.md`). All state transitions originate from the core to avoid inconsistent logic scattered across modules.
+
+## Security and Fairness
+
+- **Secure RNG**: Use cryptographically secure randomness for shuffling and card distribution. Prefer verifiable sources when available.
+- **Card Secrecy**: Only the server knows all card assignments. Clients receive only the information pertinent to them.
+- **Auditing**: Log significant actions and state transitions to immutable storage for dispute resolution.
+
+## Resilience
+
+- **Timeout Handling**: Every player action is bounded by a timer; default resolutions (auto-check/fold) occur when it expires.
+- **Disconnect Recovery**: Persist user state so that reconnecting clients can resume seamlessly. Disconnected players are treated as passive until the timer expires.
+- **Graceful Degradation**: Critical failures move the table to a Paused state while allowing unaffected tables to continue.
+
+## Testing and Upgrades
+
+- **Extensive Test Coverage**: Unit and integration tests validate state transitions and module contracts.
+- **Versioned APIs**: Public interfaces are versioned to allow backwards-compatible enhancements.
+- **Continuous Deployment**: Automate deployment with rollback capability so that upgrades can happen without downtime.
+
+## Documentation
+
+- Document all public APIs and state transitions.
+- Include examples of module interactions and recommended patterns in this `docs/` directory.
+

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -1,0 +1,69 @@
+# Poker Game States
+
+This document outlines the state machine governing a single poker table. The backend is responsible for enforcing state transitions and ensuring fairness while keeping the implementation modular.
+
+## Overview
+
+The game is represented as a deterministic state machine. Each state has well-defined entry conditions, allowed actions, exit conditions, and resolution logic for edge cases. Components such as random number generation (RNG), hand evaluation, and networking are pluggable modules so they can be swapped or upgraded without altering the overall workflow.
+
+## States
+
+### 1. **WaitingForPlayers**
+- **Entry**: Table created or round finished.
+- **Actions**: Players join, leave, or buy in. Backend verifies eligibility and reserves seats.
+- **Exit**: Minimum required players are seated and ready.
+- **Edge Cases**: 
+  - If a player disconnects before the round starts, the seat is released after a timeout.
+
+### 2. **Shuffling**
+- **Entry**: Minimum players are ready.
+- **Actions**: Deck is shuffled using a verifiable RNG module. Card order is secret to everyone except the RNG module.
+- **Exit**: Deck is prepared for dealing.
+- **Edge Cases**: 
+  - RNG failure triggers a re-shuffle using a backup generator.
+
+### 3. **Dealing**
+- **Entry**: Deck ready.
+- **Actions**: Dealer distributes cards to players and board as required for the variant.
+- **Exit**: All required cards are dealt.
+- **Edge Cases**: 
+  - Player disconnects while receiving cards: cards remain face down; if the player does not reconnect before their first action, they are folded.
+
+### 4. **BettingRound**
+This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
+
+- **Entry**: Dealing phase or previous betting round completed.
+- **Actions**: In turn order, each active player can *fold*, *check/call*, or *bet/raise*.
+- **Exit**: Betting is closed when all active players have matched the highest bet or folded.
+- **Edge Cases**:
+  - **Disconnect**: A disconnected player is treated as “timebanked”. If the action timer expires, the backend auto-folds or checks based on game rules.
+  - **Timeout**: Each player action is limited by a configurable timer. Expiration triggers auto-fold/check and records a timeout event.
+  - **Insufficient Funds**: All-in rules apply automatically; side pots are created by the backend.
+
+### 5. **Showdown**
+- **Entry**: Last betting round completed with more than one player remaining.
+- **Actions**: Hands are revealed. The evaluation module determines the winner(s).
+- **Exit**: Winning players identified.
+- **Edge Cases**: 
+  - Ties or split pots are calculated by the evaluation module.
+  - Disconnected players’ hands are revealed automatically if eligible for the pot.
+
+### 6. **Payout**
+- **Entry**: Winners determined.
+- **Actions**: Chips are awarded, pots are cleared, and statistics updated.
+- **Exit**: Payout complete.
+- **Edge Cases**: 
+  - Transfer failure triggers retry logic; if unresolved, the table enters a Paused state pending admin resolution.
+
+### 7. **Paused** *(optional)*
+- **Entry**: Critical error, manual intervention, or network partition.
+- **Actions**: No gameplay. Admins or automated recovery processes may attempt to resolve the issue.
+- **Exit**: Resolved back to previous state or terminated.
+
+## Additional Considerations
+
+- **State Persistence**: All state transitions are logged to durable storage for auditing and recovery.
+- **Reconnection Logic**: When a player reconnects, the backend replays the necessary state changes to synchronize the client.
+- **Modularity**: RNG, evaluation, networking, and persistence are separate modules communicating via defined interfaces. This enables upgrading any component without redefining game flow.
+- **Security**: Sensitive operations (e.g., deck shuffling, card dealing) happen server-side; clients only receive information they are authorized to view.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": {
     "packages": [
       "packages/snfoundry",
-      "packages/nextjs"
+      "packages/nextjs",
+      "packages/backend"
     ]
   },
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ss-2/backend",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p .",
+    "test": "tsc -p . && node tests/stateMachine.test.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,1 @@
+export * from './stateMachine';

--- a/packages/backend/src/stateMachine.ts
+++ b/packages/backend/src/stateMachine.ts
@@ -1,0 +1,122 @@
+export enum GameState {
+  WaitingForPlayers = 'WaitingForPlayers',
+  Shuffling = 'Shuffling',
+  Dealing = 'Dealing',
+  Betting = 'Betting',
+  Showdown = 'Showdown',
+  Payout = 'Payout',
+  Paused = 'Paused'
+}
+
+export enum BettingRound {
+  PreFlop = 'PreFlop',
+  Flop = 'Flop',
+  Turn = 'Turn',
+  River = 'River'
+}
+
+export type Event =
+  | { type: 'PLAYERS_READY' }
+  | { type: 'SHUFFLE_COMPLETE' }
+  | { type: 'DEAL_COMPLETE' }
+  | { type: 'BETTING_COMPLETE'; remainingPlayers: number }
+  | { type: 'SHOWDOWN_COMPLETE' }
+  | { type: 'PAYOUT_COMPLETE' }
+  | { type: 'PAUSE'; reason: string }
+  | { type: 'RESUME' };
+
+/**
+ * PokerStateMachine models the round-based state transitions for a single table.
+ * It focuses purely on state progression; networking, RNG, evaluation and I/O are pluggable.
+ */
+export class PokerStateMachine {
+  public state: GameState = GameState.WaitingForPlayers;
+  public round: BettingRound | null = null;
+  public history: GameState[] = [this.state];
+
+  private transition(next: GameState) {
+    this.state = next;
+    this.history.push(next);
+  }
+
+  dispatch(event: Event) {
+    if (this.state === GameState.Paused && event.type !== 'RESUME') {
+      return; // ignore events while paused
+    }
+
+    switch (this.state) {
+      case GameState.WaitingForPlayers:
+        if (event.type === 'PLAYERS_READY') {
+          this.transition(GameState.Shuffling);
+        }
+        break;
+      case GameState.Shuffling:
+        if (event.type === 'SHUFFLE_COMPLETE') {
+          this.transition(GameState.Dealing);
+        }
+        break;
+      case GameState.Dealing:
+        if (event.type === 'DEAL_COMPLETE') {
+          if (this.round === null) {
+            this.round = BettingRound.PreFlop;
+          } else if (this.round === BettingRound.PreFlop) {
+            this.round = BettingRound.Flop;
+          } else if (this.round === BettingRound.Flop) {
+            this.round = BettingRound.Turn;
+          } else if (this.round === BettingRound.Turn) {
+            this.round = BettingRound.River;
+          }
+          this.transition(GameState.Betting);
+        }
+        break;
+      case GameState.Betting:
+        if (event.type === 'BETTING_COMPLETE') {
+          if (event.remainingPlayers <= 1) {
+            // hand ends immediately if only one player remains
+            this.round = null;
+            this.transition(GameState.Payout);
+            break;
+          }
+          switch (this.round) {
+            case BettingRound.PreFlop:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.Flop:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.Turn:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.River:
+              this.transition(GameState.Showdown);
+              break;
+          }
+        }
+        break;
+      case GameState.Showdown:
+        if (event.type === 'SHOWDOWN_COMPLETE') {
+          this.round = null;
+          this.transition(GameState.Payout);
+        }
+        break;
+      case GameState.Payout:
+        if (event.type === 'PAYOUT_COMPLETE') {
+          this.transition(GameState.WaitingForPlayers);
+        }
+        break;
+      case GameState.Paused:
+        if (event.type === 'RESUME') {
+          // resume to last non-paused state
+          const prev = this.history[this.history.length - 2] || GameState.WaitingForPlayers;
+          this.transition(prev);
+        }
+        break;
+    }
+
+    if (event.type === 'PAUSE') {
+      this.transition(GameState.Paused);
+    }
+  }
+}
+
+export default PokerStateMachine;

--- a/packages/backend/tests/stateMachine.test.js
+++ b/packages/backend/tests/stateMachine.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert');
+const { PokerStateMachine, GameState, BettingRound } = require('../dist');
+
+const sm = new PokerStateMachine();
+assert.strictEqual(sm.state, GameState.WaitingForPlayers);
+
+sm.dispatch({ type: 'PLAYERS_READY' });
+assert.strictEqual(sm.state, GameState.Shuffling);
+
+sm.dispatch({ type: 'SHUFFLE_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Dealing);
+
+sm.dispatch({ type: 'DEAL_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Betting);
+assert.strictEqual(sm.round, BettingRound.PreFlop);
+
+sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+assert.strictEqual(sm.state, GameState.Dealing);
+
+sm.dispatch({ type: 'DEAL_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Betting);
+assert.strictEqual(sm.round, BettingRound.Flop);
+
+sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+assert.strictEqual(sm.state, GameState.Dealing);
+
+sm.dispatch({ type: 'DEAL_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Betting);
+assert.strictEqual(sm.round, BettingRound.Turn);
+
+sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+assert.strictEqual(sm.state, GameState.Dealing);
+
+sm.dispatch({ type: 'DEAL_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Betting);
+assert.strictEqual(sm.round, BettingRound.River);
+
+sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+assert.strictEqual(sm.state, GameState.Showdown);
+
+sm.dispatch({ type: 'SHOWDOWN_COMPLETE' });
+assert.strictEqual(sm.state, GameState.Payout);
+
+sm.dispatch({ type: 'PAYOUT_COMPLETE' });
+assert.strictEqual(sm.state, GameState.WaitingForPlayers);
+
+sm.dispatch({ type: 'PLAYERS_READY' });
+sm.dispatch({ type: 'PAUSE', reason: 'maintenance' });
+assert.strictEqual(sm.state, GameState.Paused);
+sm.dispatch({ type: 'RESUME' });
+assert.strictEqual(sm.state, GameState.Shuffling);
+
+console.log('State machine tests passed');

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- document state machine for a single-table poker game with disconnect and timeout handling
- add architectural guidelines covering modular design, security, resilience, and testing
- implement backend state machine to drive table phases with pause/resume and payout logic

## Testing
- `yarn install` *(fails: unrs-resolver@npm:1.11.1 couldn't be built successfully)*
- `yarn test` *(fails: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*
- `yarn workspace @ss-2/backend test`
- `yarn format:check` *(fails: Type Error: Cannot read properties of undefined (reading '/workspace/pokernft/.pnp.cjs'))*

------
https://chatgpt.com/codex/tasks/task_e_689b0391fd30832496063331a98babec