### PR TITLE
feat: add betting and payout logic

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,39 @@
+# Poker Modules
+
+This document complements [`game-states.md`](./game-states.md) by mapping the
+state machine to the main modules that drive the table.  Each module has a
+clear responsibility and can be swapped without affecting others, following the
+MVVM style used in the UI.
+
+## Core Modules
+
+| Module | Responsibility |
+| ------ | -------------- |
+| **State Machine** | Drives high level phases such as `WaitingForPlayers`, `Shuffling`, `Dealing`, `Betting`, `Showdown` and `Payout`.  Implemented in `game/stateMachine.ts` and consumed by the view‑model. |
+| **Room Engine** | Holds mutable hand data: seats, chips, deck, community cards and betting logic.  Located in `game/room.ts`. |
+| **View Model** | Bridges the state machine and React components.  `useGameStore.ts` exposes observable state and actions for the UI. |
+| **UI Components** | Render the current table, players and action bar.  Components react to state changes emitted by the view model. |
+
+## Progression
+
+1. **WaitingForPlayers** – the table is idle.  When two or more players join,
+   the view model dispatches `PLAYERS_READY` and moves to shuffling.
+2. **Shuffling/Dealing** – the deck is prepared and hole cards are dealt via the
+   room engine.
+3. **Betting Rounds** – for each street (preflop, flop, turn, river) the state
+   machine enters `Betting`.  The view model advances by calling
+   `dealFlop/Turn/River` which dispatch `BETTING_COMPLETE` followed by
+   `DEAL_COMPLETE`.
+4. **Showdown** – after the final `BETTING_COMPLETE`, the machine resolves to
+   `Showdown` where winners are evaluated.
+5. **Payout** – chips are awarded and the machine transitions back to
+   `WaitingForPlayers` ready for the next hand.
+
+## Betting & Payout
+
+The room engine exposes helpers such as `handleAction`, `isRoundComplete` and
+`payout`. The view model calls these after each player move to advance streets,
+reveal community cards and award the pot to the winning seat(s).
+
+This separation keeps rendering, state management and game rules isolated and
+mirrors the architecture described in the design guidelines.

--- a/packages/nextjs/game/room.ts
+++ b/packages/nextjs/game/room.ts
@@ -171,3 +171,21 @@ export function determineWinners(room: GameRoom): PlayerSession[] {
     }, []);
 }
 
+/** Check if the current betting round is complete */
+export function isRoundComplete(room: GameRoom): boolean {
+  const active = room.players.filter((p) => !p.hasFolded);
+  if (active.length <= 1) return true;
+  const highest = Math.max(...active.map((p) => p.currentBet));
+  return active.every((p) => p.currentBet === highest);
+}
+
+/** Split the pot equally amongst winners */
+export function payout(room: GameRoom, winners: PlayerSession[]) {
+  if (winners.length === 0) return;
+  const share = Math.floor(room.pot / winners.length);
+  winners.forEach((w) => {
+    w.chips += share;
+  });
+  room.pot = 0;
+}
+

--- a/packages/nextjs/game/stateMachine.ts
+++ b/packages/nextjs/game/stateMachine.ts
@@ -1,0 +1,122 @@
+export enum GameState {
+  WaitingForPlayers = 'WaitingForPlayers',
+  Shuffling = 'Shuffling',
+  Dealing = 'Dealing',
+  Betting = 'Betting',
+  Showdown = 'Showdown',
+  Payout = 'Payout',
+  Paused = 'Paused'
+}
+
+export enum BettingRound {
+  PreFlop = 'PreFlop',
+  Flop = 'Flop',
+  Turn = 'Turn',
+  River = 'River'
+}
+
+export type Event =
+  | { type: 'PLAYERS_READY' }
+  | { type: 'SHUFFLE_COMPLETE' }
+  | { type: 'DEAL_COMPLETE' }
+  | { type: 'BETTING_COMPLETE'; remainingPlayers: number }
+  | { type: 'SHOWDOWN_COMPLETE' }
+  | { type: 'PAYOUT_COMPLETE' }
+  | { type: 'PAUSE'; reason: string }
+  | { type: 'RESUME' };
+
+/**
+ * Lightweight table state machine used by the frontend view model.
+ * Mirrors the flow documented in {@link ../../docs/game-states.md}.
+ * Networking, RNG and evaluation live in separate modules.
+ */
+export class PokerStateMachine {
+  public state: GameState = GameState.WaitingForPlayers;
+  public round: BettingRound | null = null;
+  public history: GameState[] = [this.state];
+
+  private transition(next: GameState) {
+    this.state = next;
+    this.history.push(next);
+  }
+
+  dispatch(event: Event) {
+    if (this.state === GameState.Paused && event.type !== 'RESUME') {
+      return; // ignore events while paused
+    }
+
+    switch (this.state) {
+      case GameState.WaitingForPlayers:
+        if (event.type === 'PLAYERS_READY') {
+          this.transition(GameState.Shuffling);
+        }
+        break;
+      case GameState.Shuffling:
+        if (event.type === 'SHUFFLE_COMPLETE') {
+          this.transition(GameState.Dealing);
+        }
+        break;
+      case GameState.Dealing:
+        if (event.type === 'DEAL_COMPLETE') {
+          if (this.round === null) {
+            this.round = BettingRound.PreFlop;
+          } else if (this.round === BettingRound.PreFlop) {
+            this.round = BettingRound.Flop;
+          } else if (this.round === BettingRound.Flop) {
+            this.round = BettingRound.Turn;
+          } else if (this.round === BettingRound.Turn) {
+            this.round = BettingRound.River;
+          }
+          this.transition(GameState.Betting);
+        }
+        break;
+      case GameState.Betting:
+        if (event.type === 'BETTING_COMPLETE') {
+          if (event.remainingPlayers <= 1) {
+            // hand ends immediately if only one player remains
+            this.round = null;
+            this.transition(GameState.Payout);
+            break;
+          }
+          switch (this.round) {
+            case BettingRound.PreFlop:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.Flop:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.Turn:
+              this.transition(GameState.Dealing);
+              break;
+            case BettingRound.River:
+              this.transition(GameState.Showdown);
+              break;
+          }
+        }
+        break;
+      case GameState.Showdown:
+        if (event.type === 'SHOWDOWN_COMPLETE') {
+          this.round = null;
+          this.transition(GameState.Payout);
+        }
+        break;
+      case GameState.Payout:
+        if (event.type === 'PAYOUT_COMPLETE') {
+          this.transition(GameState.WaitingForPlayers);
+        }
+        break;
+      case GameState.Paused:
+        if (event.type === 'RESUME') {
+          const prev = this.history[this.history.length - 2] || GameState.WaitingForPlayers;
+          this.transition(prev);
+        }
+        break;
+    }
+
+    if (event.type === 'PAUSE') {
+      this.transition(GameState.Paused);
+    }
+  }
+}
+
+export default PokerStateMachine;


### PR DESCRIPTION
## Summary
- document betting and payout workflow in module overview
- add round-completion and pot payout helpers to room engine
- enhance game store with chips/pot tracking and betting actions

## Testing
- `yarn workspace @ss-2/backend test`
- `yarn test:nextjs` *(fails: require() of ES Module vite/dist/node/index.js from vitest not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689bdc89533883248f3c6cb45b2b1667