### PR TITLE
fix: alias backend source for Next.js

### DIFF
--- a/packages/nextjs/next.config.mjs
+++ b/packages/nextjs/next.config.mjs
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 import webpack from "webpack";
 import nextPWA from "next-pwa";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const withPWA = nextPWA({
   dest: "public",
@@ -37,6 +41,10 @@ const nextConfig = {
   },
   webpack: (config, { dev, isServer }) => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@ss-2/backend": path.resolve(__dirname, "../backend/src"),
+    };
     config.externals.push("pino-pretty", "lokijs", "encoding");
     config.plugins.push(
       new webpack.NormalModuleReplacementPlugin(/^node:(.*)$/, (resource) => {

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -15,7 +15,9 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "~~/*": ["./*"]
+      "~~/*": ["./*"],
+      "@ss-2/backend": ["../backend/src"],
+      "@ss-2/backend/*": ["../backend/src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add webpack alias for @ss-2/backend to backend source
- add matching TypeScript path mapping

## Testing
- `yarn build:next` *(fails: process hung, interrupted)*
- `yarn test:nextjs` *(fails: require() of ES module)*

------
https://chatgpt.com/codex/tasks/task_e_689bf21975cc8324be25eb5c4bf96e09