### PR TITLE
refactor: use viewport export

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ScaffoldStarkAppWithProviders } from "~~/components/ScaffoldStarkAppWithProviders";
 import "~~/styles/globals.css";
 import { ThemeProvider } from "~~/components/ThemeProvider";
@@ -7,10 +7,11 @@ export const metadata: Metadata = {
   title: "PokerNFTs",
   description: "Fast track your starknet journey",
   icons: "/logo.ico",
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 const ScaffoldStarkApp = ({ children }: { children: React.ReactNode }) => {


### PR DESCRIPTION
## Summary
- move viewport config to dedicated Next.js export

## Testing
- `yarn format:check` *(fails: Code style issues found in 12 files. Run Prettier with --write to fix.)*
- `yarn next:lint` *(fails: eslint-config-next tried to access next, but it isn't declared in its dependencies)*
- `yarn next:check-types` *(fails: cannot find many modules, JSX intrinsic elements)*
- `yarn test:nextjs` *(fails: require() of ES module vite/dist/node/index.js not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689bfee119988324bc504cb31c54013a