### PR TITLE
Align dependencies and enforce minimum player count

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,8 +8,8 @@
     "test": "tsc -p . && node tests/stateMachine.test.js && node tests/room.test.js"
   },
   "devDependencies": {
-    "@types/node": "^20.11.30",
+    "@types/node": "^20",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/backend/src/room.ts
+++ b/packages/backend/src/room.ts
@@ -41,10 +41,13 @@ export function addPlayer(
 
 /** Start a new hand and deal cards */
 export function startHand(room: GameRoom) {
+  if (room.players.length <= 2) {
+    room.stage = 'waiting';
+    return;
+  }
   room.deck = dealDeck();
   room.communityCards = [];
   room.pot = 0;
-  if (room.players.length === 0) return;
   if (room.stage === 'waiting') {
     room.dealerIndex = randomInt(room.players.length);
   } else {

--- a/packages/backend/tests/room.test.js
+++ b/packages/backend/tests/room.test.js
@@ -7,7 +7,20 @@ const {
   determineWinners,
   isRoundComplete,
   payout,
+  startHand,
 } = require('../dist');
+
+// startHand should only begin when more than two players are seated
+const startRoom = createRoom('start');
+addPlayer(startRoom, { id: 'a', nickname: 'A', seat: 0, chips: 100 });
+addPlayer(startRoom, { id: 'b', nickname: 'B', seat: 1, chips: 100 });
+startHand(startRoom);
+assert.strictEqual(startRoom.stage, 'waiting');
+
+addPlayer(startRoom, { id: 'c', nickname: 'C', seat: 2, chips: 100 });
+startHand(startRoom);
+assert.strictEqual(startRoom.stage, 'preflop');
+startRoom.players.forEach((p) => assert.strictEqual(p.hand.length, 2));
 
 const room = createRoom('r');
 const p1 = addPlayer(room, { id: 'p1', nickname: 'A', seat: 0, chips: 100 });

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -78,7 +78,7 @@
     "shx": "^0.4.0",
     "tailwindcss": "^3.3.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5",
+    "typescript": "^5.9.2",
     "vercel": "^33.7.1",
     "vite": "^6.2.3",
     "vitest": "^3.0.9",

--- a/packages/snfoundry/package.json
+++ b/packages/snfoundry/package.json
@@ -28,7 +28,7 @@
     "globals": "^15.8.0",
     "shx": "^0.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5",
+    "typescript": "^5.9.2",
     "typescript-eslint": "^7.16.1",
     "yargs": "^17.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ss-2/backend@workspace:packages/backend"
   dependencies:
-    "@types/node": ^20.11.30
+    "@types/node": ^20
     ts-node: ^10.9.2
-    typescript: ^5.3.3
+    typescript: ^5.9.2
   languageName: unknown
   linkType: soft
 
@@ -3819,7 +3819,7 @@ __metadata:
     tailwindcss: ^3.3.0
     ts-node: ^10.9.2
     type-fest: ^4.6.0
-    typescript: ^5
+    typescript: ^5.9.2
     usehooks-ts: ^2.13.0
     vercel: ^33.7.1
     vite: ^6.2.3
@@ -3852,7 +3852,7 @@ __metadata:
     toml: ^3.0.0
     ts-node: ^10.9.2
     tslib: ^2.6.2
-    typescript: ^5
+    typescript: ^5.9.2
     typescript-eslint: ^7.16.1
     yargs: ^17.7.2
   peerDependencies:
@@ -4268,15 +4268,6 @@ __metadata:
   dependencies:
     undici-types: ~6.21.0
   checksum: 3e3948ee0507ad079c20a335c492e6a1638bc362534fd7083e1d54237e72cbd422a4f24f170669a998b66d17214c8a03ea52d4dc02ba61fc0aed252f667b270e
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^20.11.30":
-  version: 20.19.10
-  resolution: "@types/node@npm:20.19.10"
-  dependencies:
-    undici-types: ~6.21.0
-  checksum: e294ec0d37ce5a1ae9e4c255ef837b584d793a4d2f89472d580024a4c008de0d5df595c919e96e95fcdf56bf55d567213f90c0c5874b369a30526bedfaa3f418
   languageName: node
   linkType: hard
 
@@ -13308,7 +13299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5, typescript@npm:^5.3.3, typescript@npm:^5.9.2":
+"typescript@npm:^5.9.2":
   version: 5.9.2
   resolution: "typescript@npm:5.9.2"
   bin:
@@ -13328,7 +13319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5#~builtin<compat/typescript>, typescript@patch:typescript@^5.3.3#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.9.2#~builtin<compat/typescript>":
   version: 5.9.2
   resolution: "typescript@patch:typescript@npm%3A5.9.2#~builtin<compat/typescript>::version=5.9.2&hash=29ae49"
   bin:


### PR DESCRIPTION
## Summary
- ensure a hand only starts when more than two players are seated
- add regression test for minimum player requirement
- unify TypeScript versions across backend, nextjs and snfoundry packages

## Testing
- `yarn install` *(fails: unrs-resolver couldn't be built)*
- `yarn workspace @ss-2/backend test`
- `yarn workspace @ss-2/nextjs test` *(fails: require() of ES Module not supported)*
- `yarn workspace @ss-2/snfoundry test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_689c024fbbcc83248198b983633a11dd