### PR TITLE
feat: add game timer and dealer log

### DIFF
--- a/packages/nextjs/components/ActionBar.tsx
+++ b/packages/nextjs/components/ActionBar.tsx
@@ -5,15 +5,25 @@ interface Props {
   onFlop(): void;
   onTurn(): void;
   onRiver(): void;
+  hasHandStarted: boolean;
 }
 
-export default function ActionBar({ street, ...actions }: Props) {
+export default function ActionBar({ street, hasHandStarted, ...actions }: Props) {
   return (
     <div className="flex gap-4 card p-2 rounded-full">
+      {street === "preflop" && !hasHandStarted && (
+        <button
+          onClick={actions.onStart}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+        >
+          Start
+        </button>
+      )}
       {street === "preflop" && (
         <button
           onClick={actions.onFlop}
-          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
+          disabled={!hasHandStarted}
+          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white disabled:opacity-50"
         >
           Deal Flop
         </button>

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -1,0 +1,12 @@
+import { useGameStore } from "../hooks/useGameStore";
+
+export default function DealerWindow() {
+  const logs = useGameStore((s) => s.logs);
+  return (
+    <div className="absolute bottom-4 left-4 w-64 h-32 bg-black/50 text-white p-2 rounded overflow-y-auto text-xs space-y-1">
+      {logs.map((msg, i) => (
+        <div key={i}>{msg}</div>
+      ))}
+    </div>
+  );
+}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -51,7 +51,7 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
 
 /* ─────────────────────────────────────────────────────── */
 
-export default function Table() {
+export default function Table({ timer }: { timer?: number | null }) {
   const { players, playerHands, community, joinSeat } = useGameStore();
   const [isMobile, setIsMobile] = useState(false);
   const [tableScale, setTableScale] = useState(1);
@@ -192,18 +192,14 @@ export default function Table() {
     </div>
   );
 
-  /* community cards – dead-centre via flexbox */
+  /* community cards – only reveal dealt streets */
+  const visibleCommunity = community.filter(
+    (c): c is number => c !== null,
+  );
   const communityRow = (
     <div className="absolute inset-0 flex items-center justify-center gap-2 w-full">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Card
-          key={i}
-          card={
-            community[i] !== null ? indexToCard(community[i] as number) : null
-          }
-          hidden={community[i] === null}
-          size={communityCardSize}
-        />
+      {visibleCommunity.map((code, i) => (
+        <Card key={i} card={indexToCard(code)} size={communityCardSize} />
       ))}
     </div>
   );
@@ -213,6 +209,11 @@ export default function Table() {
 
   return (
     <div className="relative flex flex-col items-center justify-center w-full h-full">
+      {typeof timer === "number" && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 text-3xl font-mono">
+          {timer.toString().padStart(2, "0")}
+        </div>
+      )}
       {/* poker-table oval */}
       <div
         className="relative rounded-full border-8 border-[var(--brand-accent)] bg-main shadow-[0_0_40px_rgba(0,0,0,0.6)]"


### PR DESCRIPTION
## Summary
- add countdown timer with manual start override
- hide undealt community cards
- log dealer and player actions in new chat window

## Testing
- `yarn test` *(fails: require() of ES Module vite)*
- `yarn lint` *(fails: Could not load eslint-config-next parser)*
- `yarn check-types` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689c1288738c83249264dcd9c6a3f58f