### PR TITLE
Add blind timer and betting controls

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -19,12 +19,17 @@ export default function PlayPage() {
     dealRiver,
     playerHands,
     players,
+    startBlindTimer,
   } = useGameStore();
   const [timer, setTimer] = useState<number | null>(null);
 
   const stageNames = ["preflop", "flop", "turn", "river", "showdown"] as const;
   const handStarted = playerHands.some((h) => h !== null);
   const activePlayers = players.filter(Boolean).length;
+
+  useEffect(() => {
+    startBlindTimer();
+  }, [startBlindTimer]);
 
   useEffect(() => {
     if (activePlayers >= 2 && !handStarted && timer === null) {

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -3,7 +3,7 @@ import { useGameStore } from "../hooks/useGameStore";
 export default function DealerWindow() {
   const logs = useGameStore((s) => s.logs);
   return (
-    <div className="absolute bottom-4 left-4 w-64 h-32 bg-black/50 text-white p-2 rounded overflow-y-auto text-xs space-y-1">
+    <div className="fixed bottom-4 left-4 w-64 max-h-32 bg-black/50 text-white p-2 rounded overflow-y-auto text-xs space-y-1">
       {logs.map((msg, i) => (
         <div key={i}>{msg}</div>
       ))}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -52,9 +52,14 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
 /* ─────────────────────────────────────────────────────── */
 
 export default function Table({ timer }: { timer?: number | null }) {
-  const { players, playerHands, community, joinSeat } = useGameStore();
+  const { players, playerHands, community, joinSeat, bigBlind } = useGameStore();
   const [isMobile, setIsMobile] = useState(false);
   const [tableScale, setTableScale] = useState(1);
+  const [bet, setBet] = useState(bigBlind);
+
+  useEffect(() => {
+    setBet(bigBlind);
+  }, [bigBlind]);
 
   useEffect(() => {
     const handle = () => {
@@ -230,13 +235,7 @@ export default function Table({ timer }: { timer?: number | null }) {
         {layout.map((_, i) => seatAt(i))}
       </div>
       <div className="mt-12 flex gap-2">
-        {[
-          "Fold",
-          "Check",
-          "Call",
-          "Bet",
-          "Raise",
-        ].map((action) => (
+        {["Fold", "Check", "Call"].map((action) => (
           <button
             key={action}
             className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
@@ -244,6 +243,26 @@ export default function Table({ timer }: { timer?: number | null }) {
             {action}
           </button>
         ))}
+        <div className="flex flex-col items-center">
+          <button className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500">Bet</button>
+          <div className="flex items-center mt-1">
+            <input
+              type="range"
+              min={bigBlind}
+              max={10000}
+              value={bet}
+              onChange={(e) => setBet(Number(e.target.value))}
+              className="w-40"
+            />
+            <input
+              type="number"
+              value={bet}
+              onChange={(e) => setBet(Number(e.target.value))}
+              className="w-16 ml-2 text-black rounded"
+            />
+          </div>
+        </div>
+        <button className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500">Raise</button>
       </div>
     </div>
   );

--- a/packages/nextjs/hooks/useGameStore.ts
+++ b/packages/nextjs/hooks/useGameStore.ts
@@ -52,6 +52,11 @@ interface GameStoreState {
   logs: string[];
   addLog: (msg: string) => void;
 
+  /** small and big blind amounts */
+  smallBlind: number;
+  bigBlind: number;
+  startBlindTimer: () => void;
+
   // Actions --------------------------------------------------------------
   reloadTableState: () => Promise<void>;
   joinSeat: (seatIdx: number) => Promise<void>;
@@ -78,6 +83,19 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
   error: null,
   logs: [],
   addLog: (msg) => set((s) => ({ logs: [...s.logs, msg] })),
+  smallBlind: 25,
+  bigBlind: 50,
+  startBlindTimer: () => {
+    const increase = () =>
+      set((s) => ({
+        smallBlind: s.smallBlind * 2,
+        bigBlind: s.bigBlind * 2,
+      }));
+    setTimeout(function tick() {
+      increase();
+      setTimeout(tick, 10 * 60 * 1000);
+    }, 10 * 60 * 1000);
+  },
 
   /** Sync Zustand state from the current room object */
   reloadTableState: async () => {
@@ -119,7 +137,7 @@ export const useGameStore = create<GameStoreState>((set, get) => ({
       id: `p${seatIdx}`,
       nickname: `Player ${seatIdx + 1}`,
       seat: seatIdx,
-      chips: 1000,
+      chips: 10000,
     });
     await get().reloadTableState();
     get().addLog(`Player ${seatIdx + 1} joined`);


### PR DESCRIPTION
## Summary
- Fix dealer log window positioning
- Add blinds that double every 10 minutes starting at 25/50 and update default chip stack
- Add bet slider with manual input defaulting to big blind

## Testing
- `yarn next:lint` *(fails: Failed to load parser './parser.js')*
- `yarn test:nextjs` *(fails: ERR_REQUIRE_ESM / parser errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c1634684883249956de3886330231