### PR TITLE
feat: improve betting controls and seat indicators

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -28,6 +28,17 @@ export default function PlayPage() {
   const activePlayers = players.filter(Boolean).length;
 
   useEffect(() => {
+    const originalBody = document.body.style.overflow;
+    const originalHtml = document.documentElement.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalBody;
+      document.documentElement.style.overflow = originalHtml;
+    };
+  }, []);
+
+  useEffect(() => {
     startBlindTimer();
   }, [startBlindTimer]);
 

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -3,7 +3,7 @@ import { useGameStore } from "../hooks/useGameStore";
 export default function DealerWindow() {
   const logs = useGameStore((s) => s.logs);
   return (
-    <div className="fixed bottom-4 left-4 w-64 max-h-32 bg-black/50 text-white p-2 rounded overflow-y-auto text-xs space-y-1">
+    <div className="fixed bottom-4 left-4 w-64 h-40 bg-black/50 text-white p-2 rounded overflow-y-auto text-xs space-y-1">
       {logs.map((msg, i) => (
         <div key={i}>{msg}</div>
       ))}

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -61,16 +61,16 @@ export default function PlayerSeat({
           </span>
         )}
 
-        <div
-          className={clsx(
-            "absolute inset-0 flex items-center justify-center rounded text-white font-semibold text-center truncate px-1 transition-colors",
-            isActive
-              ? "bg-[var(--color-accent)] text-black"
-              : "bg-black/60 hover:bg-red-500",
-          )}
-        >
-          {player.name}
-        </div>
+      <div
+        className={clsx(
+          "absolute inset-0 flex items-center justify-center rounded border text-white font-semibold text-center truncate px-1 transition-colors",
+          isActive
+            ? "bg-[var(--color-accent)] text-black border-[var(--color-accent)]"
+            : "bg-black/60 border-gray-500 hover:bg-red-500 hover:border-red-500",
+        )}
+      >
+        {player.name}
+      </div>
       </div>
 
       {/* Bet displayed below the seat */}

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -52,7 +52,15 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
 /* ─────────────────────────────────────────────────────── */
 
 export default function Table({ timer }: { timer?: number | null }) {
-  const { players, playerHands, community, joinSeat, bigBlind } = useGameStore();
+  const {
+    players,
+    playerHands,
+    community,
+    joinSeat,
+    bigBlind,
+    chips,
+    currentTurn,
+  } = useGameStore();
   const [isMobile, setIsMobile] = useState(false);
   const [tableScale, setTableScale] = useState(1);
   const [bet, setBet] = useState(bigBlind);
@@ -147,13 +155,13 @@ export default function Table({ timer }: { timer?: number | null }) {
 
     const player: Player = {
       name: nickname,
-      chips: 0,
+      chips: chips[idx] ?? 0,
       hand,
       folded: false,
       currentBet: 0,
     };
     const isDealer = idx === 1;
-    const isActive = false; // turn logic TBD
+    const isActive = idx === currentTurn;
     const reveal = idx === localIdx;
 
     const badge = (
@@ -211,6 +219,7 @@ export default function Table({ timer }: { timer?: number | null }) {
 
   const baseW = isMobile ? 420 : 820;
   const baseH = isMobile ? 680 : 520;
+  const maxBet = chips[localIdx] ?? bigBlind;
 
   return (
     <div className="relative flex flex-col items-center justify-center w-full h-full">
@@ -234,35 +243,57 @@ export default function Table({ timer }: { timer?: number | null }) {
         {/* seats */}
         {layout.map((_, i) => seatAt(i))}
       </div>
-      <div className="mt-12 flex gap-2">
-        {["Fold", "Check", "Call"].map((action) => (
-          <button
-            key={action}
-            className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
-          >
-            {action}
-          </button>
-        ))}
-        <div className="flex flex-col items-center">
-          <button className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500">Bet</button>
-          <div className="flex items-center mt-1">
-            <input
-              type="range"
-              min={bigBlind}
-              max={10000}
-              value={bet}
-              onChange={(e) => setBet(Number(e.target.value))}
-              className="w-40"
-            />
-            <input
-              type="number"
-              value={bet}
-              onChange={(e) => setBet(Number(e.target.value))}
-              className="w-16 ml-2 text-black rounded"
-            />
-          </div>
+      <div className="mt-12 flex flex-col items-center gap-2">
+        <div className="flex gap-2">
+          {["Fold", "Check", "Call", "Bet", "Raise"].map((action) => (
+            <button
+              key={action}
+              className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
+            >
+              {action}
+            </button>
+          ))}
         </div>
-        <button className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500">Raise</button>
+        <div className="flex items-center mt-1">
+          <input
+            type="range"
+            min={bigBlind}
+            max={maxBet}
+            value={bet}
+            onChange={(e) => setBet(Math.min(Number(e.target.value), maxBet))}
+            className="w-40"
+          />
+          <input
+            type="number"
+            min={bigBlind}
+            max={maxBet}
+            value={bet}
+            onChange={(e) =>
+              setBet(Math.min(Number(e.target.value), maxBet))
+            }
+            className="w-16 ml-2 text-black rounded"
+          />
+        </div>
+        <div className="flex gap-2 mt-2">
+          <button
+            className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
+            onClick={() => setBet(Math.min(bet * 2, maxBet))}
+          >
+            2x
+          </button>
+          <button
+            className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
+            onClick={() => setBet(Math.min(bet * 3, maxBet))}
+          >
+            3x
+          </button>
+          <button
+            className="px-3 py-2 rounded bg-black/60 text-white hover:bg-red-500"
+            onClick={() => setBet(maxBet)}
+          >
+            All In
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Reposition bet slider beneath action buttons and add 2x/3x/All-In quick bet controls
- Highlight active player with yellow blinking name boxes and borders
- Fix dealer info window size and restrict scrolling to it while disabling page scroll

## Testing
- `yarn next:lint` *(fails: eslint-config-next couldn't resolve next)*
- `yarn test:nextjs` *(fails: require() of ES module vite/dist/node/index.js from vitest config)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b043f3c8324a5b4fd132fd84104