### PR TITLE
Align bet chip marker with dealer button size

### DIFF
--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -124,10 +124,7 @@ export default function Table({ timer }: { timer?: number | null }) {
       setActionTimer(null);
       return;
     }
-    const id = setTimeout(
-      () => setActionTimer((t) => (t as number) - 1),
-      1000,
-    );
+    const id = setTimeout(() => setActionTimer((t) => (t as number) - 1), 1000);
     return () => clearTimeout(id);
   }, [actionTimer, playerBets, playerAction, currentTurn]);
 
@@ -241,7 +238,7 @@ export default function Table({ timer }: { timer?: number | null }) {
         {betAmount > 0 && (
           <div
             style={betStyle}
-            className={`absolute w-12 h-12 rounded-full flex items-center justify-center text-white font-semibold ${betBg}`}
+            className={`absolute w-6 h-6 rounded-full border-2 border-black flex items-center justify-center text-xs text-white font-semibold ${betBg}`}
           >
             ${betAmount}
           </div>
@@ -261,9 +258,7 @@ export default function Table({ timer }: { timer?: number | null }) {
   );
 
   /* community cards – only reveal dealt streets */
-  const visibleCommunity = community.filter(
-    (c): c is number => c !== null,
-  );
+  const visibleCommunity = community.filter((c): c is number => c !== null);
   const communityRow = (
     <div className="absolute inset-0 flex items-center justify-center gap-2 w-full">
       {visibleCommunity.map((code, i) => (


### PR DESCRIPTION
## Summary
- match bet chip markers to dealer button size
- outline bet chips with a black border for clarity

## Testing
- `yarn workspace @ss-2/nextjs prettier components/Table.tsx --write`
- `yarn workspace @ss-2/nextjs lint` *(fails: Failed to load parser './parser.js' declared in '.eslintrc.json » eslint-config-next')*
- `yarn workspace @ss-2/nextjs format:check` *(fails: Code style issues found in 28 files. Run Prettier with --write to fix.)*
- `yarn workspace @ss-2/nextjs check-types` *(fails: Cannot find module '@starknet-react/core' or its corresponding type declarations.)*
- `yarn workspace @ss-2/nextjs test` *(fails: require() of ES Module vite/dist/node/index.js from vitest config not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689c6b8a1264832498890a8ac1d5b92e