### PR TITLE
feat: add comprehensive poker room models

### DIFF
--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -7,9 +7,19 @@ export type {
   Stage,
   PlayerSession,
   GameRoom,
-  Player,
+  UiPlayer,
   GameState as EngineGameState,
   CardShape,
+  PlayerState,
+  PlayerAction,
+  Player,
+  TableState,
+  Round,
+  Pot,
+  RakeConfig,
+  Table,
+  HandAction,
+  HandLog,
 } from './types';
 export * from './utils';
 export * from './room';

--- a/packages/nextjs/backend/types.ts
+++ b/packages/nextjs/backend/types.ts
@@ -57,7 +57,7 @@ export interface GameRoom {
   deck: Card[];
 }
 
-export interface Player {
+export interface UiPlayer {
   name: string;
   chips: number;
   hand: [Card, Card] | null;
@@ -67,7 +67,7 @@ export interface Player {
 
 export interface GameState {
   deck: Card[];
-  players: Player[];
+  players: UiPlayer[];
   community: Card[];
   pot: number;
   dealerIndex: number;
@@ -78,4 +78,116 @@ export interface GameState {
 export interface CardShape {
   rank: number;
   suit: number;
+}
+
+export enum PlayerState {
+  EMPTY = 'EMPTY',
+  SEATED = 'SEATED',
+  SITTING_OUT = 'SITTING_OUT',
+  ACTIVE = 'ACTIVE',
+  FOLDED = 'FOLDED',
+  ALL_IN = 'ALL_IN',
+  DISCONNECTED = 'DISCONNECTED',
+  LEAVING = 'LEAVING',
+}
+
+export enum PlayerAction {
+  NONE = 'NONE',
+  FOLD = 'FOLD',
+  CHECK = 'CHECK',
+  CALL = 'CALL',
+  BET = 'BET',
+  RAISE = 'RAISE',
+  ALL_IN = 'ALL_IN',
+}
+
+export interface Player {
+  id: string;
+  seatIndex: number;
+  stack: number;
+  state: PlayerState;
+  hasButton: boolean;
+  autoPostBlinds: boolean;
+  timebankMs: number;
+  betThisRound: number;
+  totalCommitted: number;
+  holeCards: Card[];
+  lastAction: PlayerAction;
+}
+
+export enum TableState {
+  WAITING = 'WAITING',
+  BLINDS = 'BLINDS',
+  DEALING_HOLE = 'DEALING_HOLE',
+  PRE_FLOP = 'PRE_FLOP',
+  FLOP = 'FLOP',
+  TURN = 'TURN',
+  RIVER = 'RIVER',
+  SHOWDOWN = 'SHOWDOWN',
+  PAYOUT = 'PAYOUT',
+  ROTATE = 'ROTATE',
+  CLEANUP = 'CLEANUP',
+}
+
+export enum Round {
+  PREFLOP = 'PREFLOP',
+  FLOP = 'FLOP',
+  TURN = 'TURN',
+  RIVER = 'RIVER',
+}
+
+export interface Pot {
+  amount: number;
+  eligibleSeatSet: number[];
+}
+
+export interface RakeConfig {
+  percentage: number;
+  cap: number;
+  min: number;
+}
+
+export interface Table {
+  seats: Array<Player | null>;
+  buttonIndex: number;
+  smallBlindIndex: number;
+  bigBlindIndex: number;
+  smallBlindAmount: number;
+  bigBlindAmount: number;
+  minBuyIn: number;
+  maxBuyIn: number;
+  state: TableState;
+  deck: Card[];
+  board: Card[];
+  pots: Pot[];
+  currentRound: Round;
+  actingIndex: number | null;
+  betToCall: number;
+  minRaise: number;
+  actionTimer: number;
+  interRoundDelayMs: number;
+  dealAnimationDelayMs: number;
+  rakeConfig?: RakeConfig;
+}
+
+export interface HandAction {
+  playerId: string;
+  round: Round;
+  action: PlayerAction;
+  amount: number;
+  elapsedMs: number;
+}
+
+export interface HandLog {
+  handId: string;
+  tableId: string;
+  startTs: number;
+  endTs: number;
+  initialStacks: number[];
+  seatMap: Array<string | null>;
+  actions: HandAction[];
+  deckSeed: string;
+  pots: Pot[];
+  winners: { playerId: string; amount: number; potIndexes: number[] }[];
+  rake?: number;
 }

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -2,10 +2,10 @@
 
 import clsx from "clsx";
 import Card from "./Card";
-import type { Player, Card as TCard } from "../backend";
+import type { UiPlayer, Card as TCard } from "../backend";
 
 interface PlayerSeatProps {
-  player: Player; // player object from your Zustand store
+  player: UiPlayer; // player object from your Zustand store
   isDealer?: boolean; // show “D” marker if true
   isActive?: boolean; // highlight border when it's this player's turn
   revealCards?: boolean; // if true, show hole cards face-up

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -6,7 +6,7 @@ import { useGameStore } from "../hooks/useGameStore";
 import Card from "./Card";
 import { indexToCard } from "../backend";
 import PlayerSeat from "./PlayerSeat";
-import type { Player, Card as TCard } from "../backend";
+import type { UiPlayer, Card as TCard } from "../backend";
 
 interface SeatPos {
   x: string;
@@ -182,7 +182,7 @@ export default function Table({ timer }: { timer?: number | null }) {
       ? [indexToCard(handCodes[0]), indexToCard(handCodes[1])]
       : null;
 
-    const player: Player = {
+    const player: UiPlayer = {
       name: nickname,
       chips: chips[idx] ?? 0,
       hand,


### PR DESCRIPTION
## Summary
- add detailed enums and interfaces for players, tables and hand logs
- rename simple UI player model and update components
- export new models for wider reuse

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite)*
- `yarn next:check-types` *(fails: Cannot find module '@starknet-react/core', etc.)*
- `yarn format:check` *(fails: Code style issues found in 27 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c727b6bb883248634833315e48922