### PR TITLE
feat: add player and table state machines

### DIFF
--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -67,3 +67,37 @@ This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
 - **Modularity**: RNG, evaluation, networking, and persistence are separate modules communicating via defined interfaces. This enables upgrading any component without redefining game flow.
 - **Security**: Sensitive operations (e.g., deck shuffling, card dealing) happen server-side; clients only receive information they are authorized to view.
 
+## Seat, Player & Table States
+
+### Player State Machine (per hand)
+
+SEATED → (ACTIVE | SITTING_OUT)
+
+On new hand:
+
+- If stack ≥ BB (or allowed to post short/all-in blind), and not sitting out → **ACTIVE**.
+- Else → **SITTING_OUT**.
+
+During betting:
+
+- **ACTIVE** → **FOLDED** on Fold.
+- **ACTIVE** → **ALL_IN** if action commits all chips.
+
+Disconnection: **ACTIVE** → **DISCONNECTED** (timer); auto-fold when timer expires.
+
+Zero chips after payout: remain **SEATED** but **SITTING_OUT** (or **LEAVING** if user chose to leave).
+
+### Table State Machine (per hand)
+
+- **WAITING** (need ≥2 active seats)
+- **BLINDS** (assign button/SB/BB; collect blinds)
+- **DEALING_HOLE** (2 cards each in order starting SB → …)
+- **PRE_FLOP** (betting round)
+- **FLOP** (deal 3; betting)
+- **TURN** (deal 1; betting)
+- **RIVER** (deal 1; betting)
+- **SHOWDOWN** (if ≥2 players not folded and not all folded earlier)
+- **PAYOUT** (rank, resolve side pots, split, rake)
+- **ROTATE** (move button to next active seat)
+- **CLEANUP** (reset per-hand fields) → back to **WAITING** or **BLINDS**
+

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -27,3 +27,5 @@ export * from './hashEvaluator';
 export * from './rng';
 export * from './gameEngine';
 export * from './blindManager';
+export * from './playerStateMachine';
+export * from './tableStateMachine';

--- a/packages/nextjs/backend/playerStateMachine.ts
+++ b/packages/nextjs/backend/playerStateMachine.ts
@@ -1,0 +1,43 @@
+import { PlayerState } from './types';
+
+export type PlayerEvent =
+  | { type: 'NEW_HAND'; stack: number; bigBlind: number; sittingOut: boolean }
+  | { type: 'FOLD' }
+  | { type: 'BET_ALL_IN' }
+  | { type: 'DISCONNECT' }
+  | { type: 'RECONNECT' }
+  | { type: 'STACK_DEPLETED' }
+  | { type: 'LEAVE' };
+
+/**
+ * Reduce player state based on gameplay events.
+ * This encapsulates the per-hand state machine defined in the docs.
+ */
+export function playerStateReducer(
+  state: PlayerState,
+  event: PlayerEvent,
+): PlayerState {
+  switch (event.type) {
+    case 'NEW_HAND': {
+      if (event.sittingOut) return PlayerState.SITTING_OUT;
+      if (event.stack >= event.bigBlind || event.stack > 0) {
+        return PlayerState.ACTIVE;
+      }
+      return PlayerState.SITTING_OUT;
+    }
+    case 'FOLD':
+      return state === PlayerState.ACTIVE ? PlayerState.FOLDED : state;
+    case 'BET_ALL_IN':
+      return state === PlayerState.ACTIVE ? PlayerState.ALL_IN : state;
+    case 'DISCONNECT':
+      return state === PlayerState.ACTIVE ? PlayerState.DISCONNECTED : state;
+    case 'RECONNECT':
+      return state === PlayerState.DISCONNECTED ? PlayerState.ACTIVE : state;
+    case 'STACK_DEPLETED':
+      return PlayerState.SITTING_OUT;
+    case 'LEAVE':
+      return PlayerState.LEAVING;
+    default:
+      return state;
+  }
+}

--- a/packages/nextjs/backend/tableStateMachine.ts
+++ b/packages/nextjs/backend/tableStateMachine.ts
@@ -1,0 +1,86 @@
+import { TableState } from './types';
+
+export type TableEvent =
+  | { type: 'START_HAND'; activeSeats: number }
+  | { type: 'BLINDS_POSTED' }
+  | { type: 'DEALING_COMPLETE' }
+  | { type: 'BETTING_COMPLETE'; remainingPlayers: number }
+  | { type: 'SHOWDOWN_COMPLETE' }
+  | { type: 'PAYOUT_COMPLETE' }
+  | { type: 'ROTATION_COMPLETE' }
+  | { type: 'CLEANUP_COMPLETE'; activeSeats: number };
+
+/**
+ * Basic finite state machine for a poker table. It advances through the
+ * canonical sequence of states for a single hand.
+ */
+export class TableStateMachine {
+  public state: TableState = TableState.WAITING;
+
+  dispatch(event: TableEvent) {
+    switch (this.state) {
+      case TableState.WAITING:
+        if (event.type === 'START_HAND' && event.activeSeats >= 2) {
+          this.state = TableState.BLINDS;
+        }
+        break;
+      case TableState.BLINDS:
+        if (event.type === 'BLINDS_POSTED') {
+          this.state = TableState.DEALING_HOLE;
+        }
+        break;
+      case TableState.DEALING_HOLE:
+        if (event.type === 'DEALING_COMPLETE') {
+          this.state = TableState.PRE_FLOP;
+        }
+        break;
+      case TableState.PRE_FLOP:
+        if (event.type === 'BETTING_COMPLETE') {
+          this.state =
+            event.remainingPlayers > 1 ? TableState.FLOP : TableState.PAYOUT;
+        }
+        break;
+      case TableState.FLOP:
+        if (event.type === 'BETTING_COMPLETE') {
+          this.state =
+            event.remainingPlayers > 1 ? TableState.TURN : TableState.PAYOUT;
+        }
+        break;
+      case TableState.TURN:
+        if (event.type === 'BETTING_COMPLETE') {
+          this.state =
+            event.remainingPlayers > 1 ? TableState.RIVER : TableState.PAYOUT;
+        }
+        break;
+      case TableState.RIVER:
+        if (event.type === 'BETTING_COMPLETE') {
+          this.state =
+            event.remainingPlayers > 1
+              ? TableState.SHOWDOWN
+              : TableState.PAYOUT;
+        }
+        break;
+      case TableState.SHOWDOWN:
+        if (event.type === 'SHOWDOWN_COMPLETE') {
+          this.state = TableState.PAYOUT;
+        }
+        break;
+      case TableState.PAYOUT:
+        if (event.type === 'PAYOUT_COMPLETE') {
+          this.state = TableState.ROTATE;
+        }
+        break;
+      case TableState.ROTATE:
+        if (event.type === 'ROTATION_COMPLETE') {
+          this.state = TableState.CLEANUP;
+        }
+        break;
+      case TableState.CLEANUP:
+        if (event.type === 'CLEANUP_COMPLETE') {
+          this.state =
+            event.activeSeats >= 2 ? TableState.BLINDS : TableState.WAITING;
+        }
+        break;
+    }
+  }
+}

--- a/packages/nextjs/backend/tests/playerTableState.test.ts
+++ b/packages/nextjs/backend/tests/playerTableState.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { playerStateReducer } from '../playerStateMachine';
+import { PlayerState, TableState } from '../types';
+import { TableStateMachine } from '../tableStateMachine';
+
+describe('playerStateReducer', () => {
+  it('activates player with sufficient stack', () => {
+    const state = playerStateReducer(PlayerState.SEATED, {
+      type: 'NEW_HAND',
+      stack: 50,
+      bigBlind: 10,
+      sittingOut: false,
+    });
+    expect(state).toBe(PlayerState.ACTIVE);
+  });
+
+  it('folds player on fold action', () => {
+    const state = playerStateReducer(PlayerState.ACTIVE, { type: 'FOLD' });
+    expect(state).toBe(PlayerState.FOLDED);
+  });
+});
+
+describe('TableStateMachine', () => {
+  it('progresses through a full hand', () => {
+    const sm = new TableStateMachine();
+    sm.dispatch({ type: 'START_HAND', activeSeats: 2 });
+    expect(sm.state).toBe(TableState.BLINDS);
+    sm.dispatch({ type: 'BLINDS_POSTED' });
+    expect(sm.state).toBe(TableState.DEALING_HOLE);
+    sm.dispatch({ type: 'DEALING_COMPLETE' });
+    expect(sm.state).toBe(TableState.PRE_FLOP);
+    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    expect(sm.state).toBe(TableState.FLOP);
+    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    expect(sm.state).toBe(TableState.TURN);
+    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    expect(sm.state).toBe(TableState.RIVER);
+    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    expect(sm.state).toBe(TableState.SHOWDOWN);
+    sm.dispatch({ type: 'SHOWDOWN_COMPLETE' });
+    expect(sm.state).toBe(TableState.PAYOUT);
+    sm.dispatch({ type: 'PAYOUT_COMPLETE' });
+    expect(sm.state).toBe(TableState.ROTATE);
+    sm.dispatch({ type: 'ROTATION_COMPLETE' });
+    expect(sm.state).toBe(TableState.CLEANUP);
+    sm.dispatch({ type: 'CLEANUP_COMPLETE', activeSeats: 2 });
+    expect(sm.state).toBe(TableState.BLINDS);
+  });
+});


### PR DESCRIPTION
## Summary
- implement player state reducer for per-hand transitions
- add table state machine covering hand flow from blinds to cleanup
- document seat, player, and table state machines
- add basic tests for new state logic

## Testing
- `yarn format:check` *(fails: Code style issues found in 31 files)*
- `yarn test:nextjs` *(fails: require() of ES Module vite/dist/node/index.js from vitest not supported)*
- `yarn next:check-types` *(fails: cannot find modules and JSX intrinsic elements)*

------
https://chatgpt.com/codex/tasks/task_e_689c7ac2d8b08324814b5034db083680