### PR TITLE
feat: handle blinds and button logic

### DIFF
--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -1,4 +1,4 @@
-import { GameRoom } from './types';
+import { GameRoom, Table, Player, PlayerState, PlayerAction } from "./types";
 
 /**
  * BlindManager computes small/big blind positions and posts the blinds.
@@ -44,4 +44,103 @@ export class BlindManager {
     }
     return idx;
   }
+}
+
+/**
+ * Assign button, small blind and big blind for a {@link Table} and attempt to
+ * post the blinds according to player stacks. Returns `true` when both blinds
+ * were posted successfully, otherwise `false` indicating the hand cannot
+ * start.
+ */
+export function assignBlindsAndButton(table: Table): boolean {
+  const activeSeat = (start: number): number | null => {
+    const len = table.seats.length;
+    for (let i = 0; i < len; i++) {
+      const idx = (start + i) % len;
+      const p = table.seats[idx];
+      if (p && p.state === PlayerState.ACTIVE) return idx;
+    }
+    return null;
+  };
+
+  const postBlind = (player: Player, amount: number): boolean => {
+    if (player.stack >= amount) {
+      player.stack -= amount;
+      player.betThisRound = amount;
+      player.totalCommitted += amount;
+      player.lastAction = PlayerAction.BET;
+      return true;
+    }
+    if (player.stack > 0) {
+      player.betThisRound = player.stack;
+      player.totalCommitted += player.stack;
+      player.stack = 0;
+      player.state = PlayerState.ALL_IN;
+      player.lastAction = PlayerAction.ALL_IN;
+      return true;
+    }
+    return false;
+  };
+
+  const activePlayers = table.seats.filter(
+    (p) => p && p.state === PlayerState.ACTIVE,
+  ).length;
+  if (activePlayers < 2) return false;
+
+  const btn = activeSeat(table.buttonIndex + 1);
+  if (btn === null) return false;
+  table.buttonIndex = btn;
+  table.seats.forEach((p, i) => {
+    if (p) p.hasButton = i === btn;
+  });
+
+  let sb: number | null;
+  let bb: number | null;
+
+  const computeBlinds = () => {
+    if (activePlayers === 2) {
+      sb = btn;
+      bb = activeSeat(btn + 1);
+    } else {
+      sb = activeSeat(btn + 1);
+      bb = sb !== null ? activeSeat(sb + 1) : null;
+    }
+  };
+
+  computeBlinds();
+
+  while (sb !== null && bb !== null) {
+    const sbPlayer = table.seats[sb]!;
+    const bbPlayer = table.seats[bb]!;
+    const sbPosted = postBlind(sbPlayer, table.smallBlindAmount);
+    const bbPosted = postBlind(bbPlayer, table.bigBlindAmount);
+
+    if (sbPosted && bbPosted) break;
+
+    if (!sbPosted) sbPlayer.state = PlayerState.SITTING_OUT;
+    if (!bbPosted) bbPlayer.state = PlayerState.SITTING_OUT;
+
+    const remaining = table.seats.filter(
+      (p) => p && p.state === PlayerState.ACTIVE,
+    ).length;
+    if (remaining < 2) return false;
+
+    computeBlinds();
+    if (sb === null || bb === null) return false;
+  }
+
+  if (sb === null || bb === null) return false;
+
+  table.smallBlindIndex = sb;
+  table.bigBlindIndex = bb;
+  table.betToCall = table.bigBlindAmount;
+
+  if (activePlayers === 2) {
+    table.actingIndex = sb;
+  } else {
+    const first = activeSeat(bb + 1);
+    table.actingIndex = first ?? sb;
+  }
+
+  return true;
 }

--- a/packages/nextjs/backend/tests/blindsTable.test.ts
+++ b/packages/nextjs/backend/tests/blindsTable.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { assignBlindsAndButton } from "../blindManager";
+import {
+  Player,
+  PlayerAction,
+  PlayerState,
+  Table,
+  TableState,
+  Round,
+} from "../types";
+
+const createPlayer = (
+  id: string,
+  seatIndex: number,
+  stack: number,
+): Player => ({
+  id,
+  seatIndex,
+  stack,
+  state: PlayerState.ACTIVE,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+});
+
+describe("assignBlindsAndButton", () => {
+  it("posts blinds and sets turn order for 3 players", () => {
+    const table: Table = {
+      seats: [
+        createPlayer("a", 0, 100),
+        createPlayer("b", 1, 100),
+        createPlayer("c", 2, 100),
+      ],
+      buttonIndex: 0,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    expect(table.buttonIndex).toBe(1);
+    expect(table.smallBlindIndex).toBe(2);
+    expect(table.bigBlindIndex).toBe(0);
+    expect(table.seats[2]?.betThisRound).toBe(5);
+    expect(table.seats[0]?.betThisRound).toBe(10);
+    expect(table.actingIndex).toBe(1);
+  });
+
+  it("handles heads-up blinds and turn order", () => {
+    const table: Table = {
+      seats: [createPlayer("a", 0, 50), createPlayer("b", 1, 50)],
+      buttonIndex: 1,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    expect(table.buttonIndex).toBe(0);
+    expect(table.smallBlindIndex).toBe(0);
+    expect(table.bigBlindIndex).toBe(1);
+    expect(table.actingIndex).toBe(0);
+  });
+
+  it("recomputes blinds if SB cannot post", () => {
+    const table: Table = {
+      seats: [
+        createPlayer("a", 0, 100),
+        createPlayer("b", 1, 100),
+        createPlayer("c", 2, 0),
+      ],
+      buttonIndex: 0,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    expect(table.smallBlindIndex).toBe(0);
+    expect(table.bigBlindIndex).toBe(1);
+    expect(table.seats[2]?.state).toBe(PlayerState.SITTING_OUT);
+    expect(table.actingIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `assignBlindsAndButton` to compute button, blinds and turn order with auto-post and all-in support
- test blind assignment including heads-up and reposting when a blind cannot be posted

## Testing
- `yarn workspace @ss-2/nextjs test` *(fails: require() of ES Module vite/dist/node/index.js from vitest config)*

------
https://chatgpt.com/codex/tasks/task_e_689c7dec5f588324a5bebf3001ce4111