### PR TITLE
feat: implement dealing and betting engine

### DIFF
--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -1,0 +1,152 @@
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  Round,
+} from './types';
+
+/** Initialize betting round and determine first to act */
+export function startBettingRound(table: Table, round: Round) {
+  table.minRaise = table.bigBlindAmount;
+  if (round === Round.PREFLOP) {
+    // betToCall already equals big blind from blinds
+    const active = table.seats.filter(
+      (p) => p && p.state === PlayerState.ACTIVE,
+    );
+    if (active.length === 2) {
+      table.actingIndex = table.smallBlindIndex;
+    } else {
+      table.actingIndex = nextSeat(table, table.bigBlindIndex);
+    }
+  } else {
+    table.betToCall = 0;
+    const active = table.seats.filter(
+      (p) => p && p.state === PlayerState.ACTIVE,
+    );
+    if (active.length === 2) {
+      table.actingIndex = table.bigBlindIndex;
+    } else {
+      table.actingIndex = nextSeat(table, table.buttonIndex);
+    }
+  }
+}
+
+function nextSeat(table: Table, from: number): number | null {
+  const len = table.seats.length;
+  for (let i = 1; i <= len; i++) {
+    const idx = (from + i) % len;
+    const p = table.seats[idx];
+    if (p && p.state === PlayerState.ACTIVE) return idx;
+  }
+  return null;
+}
+
+/** Process a player's action, enforcing betting rules */
+export function applyAction(
+  table: Table,
+  seatIndex: number,
+  action: { type: PlayerAction; amount?: number },
+) {
+  if (table.actingIndex !== seatIndex) throw new Error('not players turn');
+  const player = table.seats[seatIndex];
+  if (!player || player.state !== PlayerState.ACTIVE) throw new Error('invalid');
+
+  switch (action.type) {
+    case PlayerAction.FOLD:
+      player.state = PlayerState.FOLDED;
+      player.lastAction = PlayerAction.FOLD;
+      break;
+    case PlayerAction.CHECK:
+      if (player.betThisRound !== table.betToCall)
+        throw new Error('cannot check');
+      player.lastAction = PlayerAction.CHECK;
+      break;
+    case PlayerAction.CALL: {
+      const toCall = table.betToCall - player.betThisRound;
+      const commit = Math.min(toCall, player.stack);
+      player.stack -= commit;
+      player.betThisRound += commit;
+      player.totalCommitted += commit;
+      player.lastAction = commit < toCall ? PlayerAction.ALL_IN : PlayerAction.CALL;
+      if (player.stack === 0) player.state = PlayerState.ALL_IN;
+      break;
+    }
+    case PlayerAction.BET: {
+      if (table.betToCall !== 0) throw new Error('cannot bet');
+      const amount = action.amount ?? 0;
+      if (amount < table.minRaise) throw new Error('bet too small');
+      const commit = Math.min(amount, player.stack);
+      player.stack -= commit;
+      player.betThisRound += commit;
+      player.totalCommitted += commit;
+      table.betToCall = player.betThisRound;
+      table.minRaise = commit;
+      player.lastAction = commit < amount ? PlayerAction.ALL_IN : PlayerAction.BET;
+      if (player.stack === 0) player.state = PlayerState.ALL_IN;
+      break;
+    }
+    case PlayerAction.RAISE: {
+      if (table.betToCall === 0) throw new Error('nothing to raise');
+      const callAmt = table.betToCall - player.betThisRound;
+      const raiseAmt = action.amount ?? 0;
+      const total = callAmt + raiseAmt;
+      const commit = Math.min(total, player.stack);
+      player.stack -= commit;
+      player.betThisRound += commit;
+      player.totalCommitted += commit;
+      if (commit > callAmt) {
+        table.betToCall = player.betThisRound;
+        if (commit - callAmt >= table.minRaise) {
+          table.minRaise = commit - callAmt;
+        }
+      }
+      player.lastAction = commit < total ? PlayerAction.ALL_IN : PlayerAction.RAISE;
+      if (player.stack === 0) player.state = PlayerState.ALL_IN;
+      break;
+    }
+    case PlayerAction.ALL_IN: {
+      const commit = player.stack;
+      player.stack = 0;
+      player.betThisRound += commit;
+      player.totalCommitted += commit;
+      if (player.betThisRound > table.betToCall) {
+        const diff = player.betThisRound - table.betToCall;
+        table.betToCall = player.betThisRound;
+        if (diff >= table.minRaise) table.minRaise = diff;
+      }
+      player.state = PlayerState.ALL_IN;
+      player.lastAction = PlayerAction.ALL_IN;
+      break;
+    }
+  }
+
+  // advance turn
+  table.actingIndex = nextToAct(table, seatIndex);
+}
+
+function nextToAct(table: Table, from: number): number | null {
+  const len = table.seats.length;
+  for (let i = 1; i <= len; i++) {
+    const idx = (from + i) % len;
+    const p = table.seats[idx];
+    if (!p) continue;
+    if (p.state !== PlayerState.FOLDED && p.state !== PlayerState.ALL_IN) {
+      if (p.betThisRound < table.betToCall) return idx;
+    }
+  }
+  // if no one needs to act, round complete
+  return null;
+}
+
+/** Determine if betting round is complete */
+export function isRoundComplete(table: Table): boolean {
+  const live = table.seats.filter(
+    (p) => p && p.state !== PlayerState.FOLDED,
+  ) as Player[];
+  if (live.length <= 1) return true;
+  return live.every(
+    (p) =>
+      p.state === PlayerState.ALL_IN || p.betThisRound === table.betToCall,
+  );
+}

--- a/packages/nextjs/backend/dealer.ts
+++ b/packages/nextjs/backend/dealer.ts
@@ -1,0 +1,30 @@
+import { Table, PlayerState, Round } from './types';
+import { draw } from './utils';
+
+/** Deal two hole cards to each active seat starting from the small blind */
+export function dealHoleCards(table: Table) {
+  if (!table.deck.length) return;
+  const len = table.seats.length;
+  // deal one card at a time, starting from small blind
+  for (let i = 0; i < 2; i++) {
+    for (let offset = 0; offset < len; offset++) {
+      const idx = (table.smallBlindIndex + offset) % len;
+      const player = table.seats[idx];
+      if (player && player.state !== PlayerState.SITTING_OUT) {
+        player.holeCards.push(draw(table.deck));
+      }
+    }
+  }
+}
+
+/** Deal board cards for the given round with optional burn */
+export function dealBoard(table: Table, round: Round) {
+  if (!table.deck.length) return;
+  // burn card
+  draw(table.deck);
+  if (round === Round.FLOP) {
+    table.board.push(draw(table.deck), draw(table.deck), draw(table.deck));
+  } else if (round === Round.TURN || round === Round.RIVER) {
+    table.board.push(draw(table.deck));
+  }
+}

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -29,3 +29,5 @@ export * from './gameEngine';
 export * from './blindManager';
 export * from './playerStateMachine';
 export * from './tableStateMachine';
+export * from './dealer';
+export * from './bettingEngine';

--- a/packages/nextjs/backend/tests/dealerBetting.test.ts
+++ b/packages/nextjs/backend/tests/dealerBetting.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from '../types';
+import { dealHoleCards } from '../dealer';
+import { assignBlindsAndButton } from '../blindManager';
+import { startBettingRound, applyAction, isRoundComplete } from '../bettingEngine';
+
+const card = (rank: string, suit: string) => ({ rank: rank as any, suit: suit as any });
+const createPlayer = (id: string, seatIndex: number, stack: number): Player => ({
+  id,
+  seatIndex,
+  stack,
+  state: PlayerState.ACTIVE,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+});
+
+describe('Dealer & BettingEngine', () => {
+  it('deals hole cards starting from small blind', () => {
+    const table: Table = {
+      seats: [createPlayer('a',0,0), createPlayer('b',1,0), createPlayer('c',2,0)],
+      buttonIndex: 0,
+      smallBlindIndex: 1,
+      bigBlindIndex: 2,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.DEALING_HOLE,
+      deck: [
+        card('6','s'),
+        card('5','s'),
+        card('4','s'),
+        card('3','s'),
+        card('2','s'),
+        card('1','s'),
+      ],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+    dealHoleCards(table);
+    expect(table.seats[1]?.holeCards).toEqual([card('1','s'), card('4','s')]);
+    expect(table.seats[2]?.holeCards).toEqual([card('2','s'), card('5','s')]);
+    expect(table.seats[0]?.holeCards).toEqual([card('3','s'), card('6','s')]);
+  });
+
+  it('enforces min-raise and round completion', () => {
+    const table: Table = {
+      seats: [
+        createPlayer('a',0,40),
+        createPlayer('b',1,100),
+        createPlayer('c',2,20),
+      ],
+      buttonIndex: 0,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    startBettingRound(table, Round.PREFLOP);
+    expect(table.betToCall).toBe(10);
+    expect(table.actingIndex).toBe(1);
+    applyAction(table,1,{type:PlayerAction.RAISE, amount:20}); // raise to 30
+    expect(table.betToCall).toBe(30);
+    expect(table.minRaise).toBe(20);
+    applyAction(table,2,{type:PlayerAction.FOLD});
+    applyAction(table,0,{type:PlayerAction.ALL_IN}); // to 40 total, raise 10 (<minRaise)
+    expect(table.betToCall).toBe(40);
+    expect(table.minRaise).toBe(20);
+    applyAction(table,1,{type:PlayerAction.CALL});
+    expect(isRoundComplete(table)).toBe(true);
+    expect(table.actingIndex).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add dealer utilities for hole and board dealing order
- introduce betting engine with min-raise logic and action handling
- cover dealer and betting engine with new tests

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite)*

------
https://chatgpt.com/codex/tasks/task_e_689c80d3905c8324ba3ee4d3c5f8ca7a