### PR TITLE
Implement comprehensive pot accounting and rake

### DIFF
--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -5,6 +5,7 @@ import {
   PlayerAction,
   Round,
 } from './types';
+import { recomputePots } from './potManager';
 
 /** Initialize betting round and determine first to act */
 export function startBettingRound(table: Table, round: Round) {
@@ -119,6 +120,11 @@ export function applyAction(
       player.lastAction = PlayerAction.ALL_IN;
       break;
     }
+  }
+
+  // if player is now all-in, recompute pots based on total commitments
+  if (player.state === PlayerState.ALL_IN) {
+    recomputePots(table);
   }
 
   // advance turn

--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -1,4 +1,5 @@
 import { GameRoom, Table, Player, PlayerState, PlayerAction } from "./types";
+import { recomputePots } from "./potManager";
 
 /**
  * BlindManager computes small/big blind positions and posts the blinds.
@@ -140,6 +141,14 @@ export function assignBlindsAndButton(table: Table): boolean {
   } else {
     const first = activeSeat(bb + 1);
     table.actingIndex = first ?? sb;
+  }
+
+  // recompute pots if any blind went all-in
+  if (
+    table.seats[sb]?.state === PlayerState.ALL_IN ||
+    table.seats[bb]?.state === PlayerState.ALL_IN
+  ) {
+    recomputePots(table);
   }
 
   return true;

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -31,3 +31,4 @@ export * from './playerStateMachine';
 export * from './tableStateMachine';
 export * from './dealer';
 export * from './bettingEngine';
+export * from './potManager';

--- a/packages/nextjs/backend/potManager.ts
+++ b/packages/nextjs/backend/potManager.ts
@@ -1,0 +1,72 @@
+import { Table, Player, PlayerState, Pot } from './types';
+
+/**
+ * Recompute main and side pots based on each player's total commitment.
+ * Players are sorted by their committed amounts to build threshold layers
+ * where each layer represents a new pot.
+ */
+export function recomputePots(table: Table) {
+  const players = table.seats.filter((p): p is Player => !!p && p.totalCommitted > 0);
+  if (players.length === 0) {
+    table.pots = [];
+    return;
+  }
+
+  const thresholds = Array.from(new Set(players.map((p) => p.totalCommitted))).sort(
+    (a, b) => a - b,
+  );
+
+  let previous = 0;
+  const pots: Pot[] = [];
+  for (const threshold of thresholds) {
+    const contributors = players.filter((p) => p.totalCommitted >= threshold);
+    const amount = (threshold - previous) * contributors.length;
+    const eligibleSeatSet = contributors
+      .filter((p) => p.state !== PlayerState.FOLDED)
+      .map((p) => p.seatIndex);
+    pots.push({ amount, eligibleSeatSet });
+    previous = threshold;
+  }
+
+  table.pots = pots;
+}
+
+/**
+ * Reset per-round betting state for a new betting round. Total commitment is
+ * preserved while individual round bets and bet-to-call are cleared.
+ */
+export function resetForNextRound(table: Table) {
+  table.betToCall = 0;
+  table.seats.forEach((p) => {
+    if (p) p.betThisRound = 0;
+  });
+}
+
+/**
+ * Apply rake to each pot if a rake configuration is present on the table.
+ * Returns the total rake taken across all pots.
+ */
+export function applyRake(table: Table): number {
+  const config = table.rakeConfig;
+  if (!config) return 0;
+
+  let total = 0;
+  table.pots.forEach((pot) => {
+    if (pot.amount < config.min) {
+      pot.rake = 0;
+      return;
+    }
+    const raw = Math.floor(pot.amount * config.percentage);
+    const rake = Math.min(raw, config.cap);
+    pot.amount -= rake;
+    pot.rake = rake;
+    total += rake;
+  });
+  return total;
+}
+
+export default {
+  recomputePots,
+  resetForNextRound,
+  applyRake,
+};

--- a/packages/nextjs/backend/tests/potAccounting.test.ts
+++ b/packages/nextjs/backend/tests/potAccounting.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from '../types';
+import { recomputePots, applyRake, resetForNextRound } from '../potManager';
+
+const createPlayer = (
+  id: string,
+  seatIndex: number,
+  committed: number,
+  state: PlayerState = PlayerState.ACTIVE,
+): Player => ({
+  id,
+  seatIndex,
+  stack: 0,
+  state,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: committed,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+});
+
+const createTable = (players: Player[], extra: Partial<Table> = {}): Table => ({
+  seats: players,
+  buttonIndex: 0,
+  smallBlindIndex: 0,
+  bigBlindIndex: 0,
+  smallBlindAmount: 5,
+  bigBlindAmount: 10,
+  minBuyIn: 0,
+  maxBuyIn: 0,
+  state: TableState.PRE_FLOP,
+  deck: [],
+  board: [],
+  pots: [],
+  currentRound: Round.PREFLOP,
+  actingIndex: null,
+  betToCall: 0,
+  minRaise: 0,
+  actionTimer: 0,
+  interRoundDelayMs: 0,
+  dealAnimationDelayMs: 0,
+  ...extra,
+});
+
+describe('pot accounting', () => {
+  it('creates main and side pots based on commitments', () => {
+    const table = createTable([
+      createPlayer('a', 0, 100),
+      createPlayer('b', 1, 200),
+      createPlayer('c', 2, 300),
+    ]);
+    recomputePots(table);
+    expect(table.pots).toEqual([
+      { amount: 300, eligibleSeatSet: [0, 1, 2] },
+      { amount: 200, eligibleSeatSet: [1, 2] },
+      { amount: 100, eligibleSeatSet: [2] },
+    ]);
+  });
+
+  it('excludes folded players from eligibility but counts their chips', () => {
+    const table = createTable([
+      createPlayer('a', 0, 100),
+      createPlayer('b', 1, 200),
+      createPlayer('c', 2, 100, PlayerState.FOLDED),
+    ]);
+    recomputePots(table);
+    expect(table.pots).toEqual([
+      { amount: 300, eligibleSeatSet: [0, 1] },
+      { amount: 100, eligibleSeatSet: [1] },
+    ]);
+  });
+
+  it('applies rake to each pot', () => {
+    const table = createTable(
+      [createPlayer('a', 0, 100), createPlayer('b', 1, 100)],
+      { rakeConfig: { percentage: 0.1, cap: 5, min: 0 } },
+    );
+    recomputePots(table);
+    const total = applyRake(table);
+    expect(total).toBe(5);
+    expect(table.pots[0].amount).toBe(195);
+    expect(table.pots[0].rake).toBe(5);
+  });
+
+  it('resets round bets while keeping commitments', () => {
+    const p1 = createPlayer('a', 0, 50);
+    p1.betThisRound = 20;
+    const p2 = createPlayer('b', 1, 70);
+    p2.betThisRound = 40;
+    const table = createTable([p1, p2], { betToCall: 40 });
+    resetForNextRound(table);
+    expect(table.betToCall).toBe(0);
+    expect(table.seats[0]?.betThisRound).toBe(0);
+    expect(table.seats[1]?.betThisRound).toBe(0);
+    expect(table.seats[0]?.totalCommitted).toBe(50);
+    expect(table.seats[1]?.totalCommitted).toBe(70);
+  });
+});

--- a/packages/nextjs/backend/types.ts
+++ b/packages/nextjs/backend/types.ts
@@ -139,6 +139,8 @@ export enum Round {
 export interface Pot {
   amount: number;
   eligibleSeatSet: number[];
+  /** rake taken from this pot */
+  rake?: number;
 }
 
 export interface RakeConfig {


### PR DESCRIPTION
## Summary
- add pot manager to recompute main/side pots, reset bets and apply rake
- recompute pots on all-in actions and blinds
- track rake per pot in type definitions and add tests for pot accounting

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite from vitest config)*
- `yarn format:check` *(warn: Code style issues found in 35 files)*

------
https://chatgpt.com/codex/tasks/task_e_689c8568867c8324be86226095ece616