### PR TITLE
Document showdown payouts and distribute pot remainders

### DIFF
--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -9,31 +9,35 @@ The game is represented as a deterministic state machine. Each state has well-de
 ## States
 
 ### 1. **WaitingForPlayers**
+
 - **Entry**: Table created or round finished.
 - **Actions**: Players join, leave, or buy in. Backend verifies eligibility and reserves seats.
 - **Exit**: Minimum required players are seated and ready.
-- **Edge Cases**: 
+- **Edge Cases**:
   - If a player disconnects before the round starts, the seat is released after a timeout.
 
 ### 2. **Shuffling**
+
 - **Entry**: Minimum players are ready.
 - **Actions**: Deck is shuffled using a verifiable RNG module. Card order is secret to everyone except the RNG module.
 - **Exit**: Deck is prepared for dealing.
-- **Edge Cases**: 
+- **Edge Cases**:
   - RNG failure triggers a re-shuffle using a backup generator.
 
 ### 3. **Dealing**
+
 - **Entry**: Deck ready.
 - **Actions**: Dealer distributes cards to players and board as required for the variant.
 - **Exit**: All required cards are dealt.
-- **Edge Cases**: 
+- **Edge Cases**:
   - Player disconnects while receiving cards: cards remain face down; if the player does not reconnect before their first action, they are folded.
 
 ### 4. **BettingRound**
+
 This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
 
 - **Entry**: Dealing phase or previous betting round completed.
-- **Actions**: In turn order, each active player can *fold*, *check/call*, or *bet/raise*.
+- **Actions**: In turn order, each active player can _fold_, _check/call_, or _bet/raise_.
 - **Exit**: Betting is closed when all active players have matched the highest bet or folded.
 - **Edge Cases**:
   - **Disconnect**: A disconnected player is treated as “timebanked”. If the action timer expires, the backend auto-folds or checks based on game rules.
@@ -41,21 +45,26 @@ This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
   - **Insufficient Funds**: All-in rules apply automatically; side pots are created by the backend.
 
 ### 5. **Showdown**
+
 - **Entry**: Last betting round completed with more than one player remaining.
 - **Actions**: Hands are revealed. The evaluation module determines the winner(s).
 - **Exit**: Winning players identified.
-- **Edge Cases**: 
+- **Edge Cases**:
   - Ties or split pots are calculated by the evaluation module.
   - Disconnected players’ hands are revealed automatically if eligible for the pot.
 
 ### 6. **Payout**
+
 - **Entry**: Winners determined.
 - **Actions**: Chips are awarded, pots are cleared, and statistics updated.
 - **Exit**: Payout complete.
-- **Edge Cases**: 
+- **Edge Cases**:
   - Transfer failure triggers retry logic; if unresolved, the table enters a Paused state pending admin resolution.
 
-### 7. **Paused** *(optional)*
+For detailed reveal order, evaluation, and payout rules, see [Showdown & Payouts](./showdown-payouts.md).
+
+### 7. **Paused** _(optional)_
+
 - **Entry**: Critical error, manual intervention, or network partition.
 - **Actions**: No gameplay. Admins or automated recovery processes may attempt to resolve the issue.
 - **Exit**: Resolved back to previous state or terminated.
@@ -100,4 +109,3 @@ Zero chips after payout: remain **SEATED** but **SITTING_OUT** (or **LEAVING** i
 - **PAYOUT** (rank, resolve side pots, split, rake)
 - **ROTATE** (move button to next active seat)
 - **CLEANUP** (reset per-hand fields) → back to **WAITING** or **BLINDS**
-

--- a/docs/showdown-payouts.md
+++ b/docs/showdown-payouts.md
@@ -1,0 +1,27 @@
+# Showdown & Payouts
+
+This document outlines how a hand transitions from showdown to awarding chips.
+
+## When does a showdown occur?
+
+- End of river betting when at least two players have not folded.
+- An earlier betting round ends with one or more players all-in and all remaining board cards have been dealt.
+
+## Reveal order
+
+- If the river was checked down, the first player to the left of the button exposes their hand first (table policy may vary).
+- Otherwise the last aggressor reveals first. Remaining eligible players may either muck or show to claim the pot.
+
+## Hand evaluation
+
+For each pot that still has contenders:
+
+1. Consider only non-folded players whose chips make them eligible for that pot.
+2. From each player's two hole cards and the five community cards, compute the best five-card hand.
+3. Rank hands and identify any ties.
+4. Split the pot equally among the winning players. If the chips cannot be divided evenly, award the leftover chip(s) by house rule (e.g. first winner clockwise from the button).
+
+## Payout
+
+- Transfer chips from each pot to its winning players and update their stacks.
+- A player reduced to zero chips cannot post blinds on the next hand and is marked `SITTING_OUT` or removed according to table policy.

--- a/packages/nextjs/backend/room.ts
+++ b/packages/nextjs/backend/room.ts
@@ -184,8 +184,21 @@ export function isRoundComplete(room: GameRoom): boolean {
 export function payout(room: GameRoom, winners: PlayerSession[]) {
   if (winners.length === 0) return;
   const share = Math.floor(room.pot / winners.length);
+  const remainder = room.pot - share * winners.length;
   winners.forEach((w) => {
     w.chips += share;
   });
+  if (remainder > 0) {
+    const ordered: PlayerSession[] = [];
+    for (let i = 1; i <= room.players.length; i++) {
+      const idx = (room.dealerIndex + i) % room.players.length;
+      const player = room.players[idx];
+      if (winners.includes(player)) ordered.push(player);
+    }
+    for (let i = 0; i < remainder; i++) {
+      ordered[i % ordered.length].chips += 1;
+    }
+  }
   room.pot = 0;
+  room.players = room.players.filter((p) => p.chips > 0);
 }

--- a/packages/nextjs/backend/tests/room.test.js
+++ b/packages/nextjs/backend/tests/room.test.js
@@ -1,4 +1,4 @@
-const assert = require('node:assert');
+const assert = require("node:assert");
 const {
   createRoom,
   addPlayer,
@@ -9,18 +9,18 @@ const {
   payout,
   startHand,
   BlindManager,
-} = require('../dist');
+} = require("../dist");
 
 // startHand should only begin when more than two players are seated
-const startRoom = createRoom('start');
-addPlayer(startRoom, { id: 'a', nickname: 'A', seat: 0, chips: 100 });
-addPlayer(startRoom, { id: 'b', nickname: 'B', seat: 1, chips: 100 });
+const startRoom = createRoom("start");
+addPlayer(startRoom, { id: "a", nickname: "A", seat: 0, chips: 100 });
+addPlayer(startRoom, { id: "b", nickname: "B", seat: 1, chips: 100 });
 startHand(startRoom);
-assert.strictEqual(startRoom.stage, 'waiting');
+assert.strictEqual(startRoom.stage, "waiting");
 
-addPlayer(startRoom, { id: 'c', nickname: 'C', seat: 2, chips: 100 });
+addPlayer(startRoom, { id: "c", nickname: "C", seat: 2, chips: 100 });
 startHand(startRoom);
-assert.strictEqual(startRoom.stage, 'preflop');
+assert.strictEqual(startRoom.stage, "preflop");
 startRoom.players.forEach((p) => assert.strictEqual(p.hand.length, 2));
 
 // blinds should be posted and action starts after the big blind
@@ -34,12 +34,12 @@ assert.strictEqual(
   bm.nextActiveIndex(startRoom, bb + 1),
 );
 
-const room = createRoom('r');
-const p1 = addPlayer(room, { id: 'p1', nickname: 'A', seat: 0, chips: 100 });
-const p2 = addPlayer(room, { id: 'p2', nickname: 'B', seat: 1, chips: 100 });
+const room = createRoom("r");
+const p1 = addPlayer(room, { id: "p1", nickname: "A", seat: 0, chips: 100 });
+const p2 = addPlayer(room, { id: "p2", nickname: "B", seat: 1, chips: 100 });
 
-handleAction(room, p1.id, { type: 'raise', amount: 20 });
-handleAction(room, p2.id, { type: 'call' });
+handleAction(room, p1.id, { type: "raise", amount: 20 });
+handleAction(room, p2.id, { type: "call" });
 assert.strictEqual(room.pot, 40);
 assert.strictEqual(p1.chips, 80);
 assert.strictEqual(p2.chips, 80);
@@ -52,34 +52,34 @@ assert.strictEqual(room.players[0].isTurn, true);
 
 // showdown winner test
 const showdownRoom = {
-  id: 'r',
+  id: "r",
   players: [
     {
-      id: 'a',
-      nickname: 'A',
-      tableId: 'r',
+      id: "a",
+      nickname: "A",
+      tableId: "r",
       seat: 0,
       chips: 0,
       isDealer: false,
       isTurn: false,
       hand: [
-        { rank: 'A', suit: '\u2660' },
-        { rank: 'K', suit: '\u2666' },
+        { rank: "A", suit: "\u2660" },
+        { rank: "K", suit: "\u2666" },
       ],
       hasFolded: false,
       currentBet: 0,
     },
     {
-      id: 'b',
-      nickname: 'B',
-      tableId: 'r',
+      id: "b",
+      nickname: "B",
+      tableId: "r",
       seat: 1,
       chips: 0,
       isDealer: false,
       isTurn: false,
       hand: [
-        { rank: 'Q', suit: '\u2660' },
-        { rank: 'J', suit: '\u2666' },
+        { rank: "Q", suit: "\u2660" },
+        { rank: "J", suit: "\u2666" },
       ],
       hasFolded: false,
       currentBet: 0,
@@ -87,14 +87,14 @@ const showdownRoom = {
   ],
   dealerIndex: 0,
   currentTurnIndex: 0,
-  stage: 'showdown',
+  stage: "showdown",
   pot: 100,
   communityCards: [
-    { rank: '2', suit: '\u2663' },
-    { rank: '3', suit: '\u2663' },
-    { rank: '4', suit: '\u2663' },
-    { rank: '5', suit: '\u2663' },
-    { rank: '7', suit: '\u2666' },
+    { rank: "2", suit: "\u2663" },
+    { rank: "3", suit: "\u2663" },
+    { rank: "4", suit: "\u2663" },
+    { rank: "5", suit: "\u2663" },
+    { rank: "7", suit: "\u2666" },
   ],
   minBet: 0,
   deck: [],
@@ -102,7 +102,7 @@ const showdownRoom = {
 
 const winners = determineWinners(showdownRoom);
 assert.strictEqual(winners.length, 1);
-assert.strictEqual(winners[0].id, 'a');
+assert.strictEqual(winners[0].id, "a");
 
 payout(showdownRoom, winners);
 assert.strictEqual(showdownRoom.pot, 0);
@@ -110,4 +110,116 @@ assert.strictEqual(winners[0].chips, 100);
 
 assert.ok(isRoundComplete(room));
 
-console.log('Room tests passed');
+// payout remainder test
+const remainderRoom = {
+  id: "r",
+  players: [
+    {
+      id: "a",
+      nickname: "A",
+      tableId: "r",
+      seat: 0,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+    {
+      id: "b",
+      nickname: "B",
+      tableId: "r",
+      seat: 1,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+    {
+      id: "c",
+      nickname: "C",
+      tableId: "r",
+      seat: 2,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+  ],
+  dealerIndex: 0,
+  currentTurnIndex: 0,
+  stage: "showdown",
+  pot: 5,
+  communityCards: [],
+  minBet: 0,
+  deck: [],
+};
+
+const remainderWinners = [remainderRoom.players[1], remainderRoom.players[2]];
+payout(remainderRoom, remainderWinners);
+assert.strictEqual(remainderRoom.pot, 0);
+assert.strictEqual(remainderRoom.players[1].chips, 3);
+assert.strictEqual(remainderRoom.players[2].chips, 2);
+
+// players with zero chips are removed before the next hand
+const bustRoom = {
+  id: "br",
+  players: [
+    {
+      id: "a",
+      nickname: "A",
+      tableId: "br",
+      seat: 0,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+    {
+      id: "b",
+      nickname: "B",
+      tableId: "br",
+      seat: 1,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+    {
+      id: "c",
+      nickname: "C",
+      tableId: "br",
+      seat: 2,
+      chips: 0,
+      isDealer: false,
+      isTurn: false,
+      hand: [],
+      hasFolded: false,
+      currentBet: 0,
+    },
+  ],
+  dealerIndex: 0,
+  currentTurnIndex: 0,
+  stage: "showdown",
+  pot: 30,
+  communityCards: [],
+  minBet: 0,
+  deck: [],
+};
+
+const bustWinners = [bustRoom.players[2]];
+payout(bustRoom, bustWinners);
+assert.strictEqual(bustRoom.players.length, 1);
+assert.strictEqual(bustRoom.players[0].id, "c");
+assert.strictEqual(bustRoom.players[0].chips, 30);
+
+console.log("Room tests passed");


### PR DESCRIPTION
## Summary
- Add detailed Showdown & Payouts procedure documentation
- Cross-reference showdown rules from game state docs
- Handle pot remainders by awarding extra chips clockwise from the dealer and remove broke players before the next hand

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite not supported)*
- `yarn test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_689c960f0f088324af69feec2a8b0af4