### PR TITLE
feat: add timer service with auto actions and delays

### DIFF
--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -17,6 +17,7 @@ These guidelines describe architectural principles for the poker backend to ensu
 ## Resilience
 
 - **Timeout Handling**: Every player action is bounded by a timer; default resolutions (auto-check/fold) occur when it expires.
+- **Timebank**: A per-player reserve extends the action timer automatically before a forced action is applied.
 - **Disconnect Recovery**: Persist user state so that reconnecting clients can resume seamlessly. Disconnected players are treated as passive until the timer expires.
 - **Graceful Degradation**: Critical failures move the table to a Paused state while allowing unaffected tables to continue.
 

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -28,6 +28,7 @@ The game is represented as a deterministic state machine. Each state has well-de
 
 - **Entry**: Deck ready.
 - **Actions**: Dealer distributes cards to players and board as required for the variant.
+- **Timing**: Each card is dealt with `dealAnimationDelayMs` between events to pace animations.
 - **Exit**: All required cards are dealt.
 - **Edge Cases**:
   - Player disconnects while receiving cards: cards remain face down; if the player does not reconnect before their first action, they are folded.
@@ -40,8 +41,8 @@ This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
 - **Actions**: In turn order, each active player can _fold_, _check/call_, or _bet/raise_.
 - **Exit**: Betting is closed when all active players have matched the highest bet or folded.
 - **Edge Cases**:
-  - **Disconnect**: A disconnected player is treated as “timebanked”. If the action timer expires, the backend auto-folds or checks based on game rules.
-  - **Timeout**: Each player action is limited by a configurable timer. Expiration triggers auto-fold/check and records a timeout event.
+  - **Disconnect**: A disconnected player receives a separate grace timer. On expiry the backend applies the same resolution as a normal timeout.
+  - **Timeout**: Each player action is limited by a configurable timer. When it expires the player's timebank is consumed automatically; if none remains the backend auto-checks or folds based on game rules.
   - **Insufficient Funds**: All-in rules apply automatically; side pots are created by the backend.
 
 ### 5. **Showdown**
@@ -57,7 +58,7 @@ This state repeats for each betting phase (Pre-Flop, Flop, Turn, River).
 
 - **Entry**: Winners determined.
 - **Actions**: Chips are awarded, pots are cleared, and statistics updated.
-- **Exit**: Payout complete.
+- **Exit**: Payout complete. The table then pauses for `interRoundDelayMs` before the next hand.
 - **Edge Cases**:
   - Transfer failure triggers retry logic; if unresolved, the table enters a Paused state pending admin resolution.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -16,7 +16,7 @@ MVVM style used in the UI.
 | **BettingEngine**        | Manages turn order, validates actions and raise sizes, tracks `betToCall`/`minRaise` and detects round completion.                     |
 | **PotManager**           | Tracks commitments, builds main and side pots on all‑ins, applies rake and settles payouts.                                            |
 | **HandEvaluator**        | Ranks seven‑card hands, resolves ties and supports split pots.                                                                         |
-| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry.                         |
+| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry and provides deal/inter‑round delay helpers. |
 | **EventBus**             | Emits state changes to clients and queues validated commands to the server.                                                            |
 | **Persistence/Audit**    | Records immutable hand and action logs for settlements and anti‑fraud analysis.                                                        |
 | **RulesConfig**          | Defines game parameters such as blinds, rake and buy‑in limits.                                                                        |

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -32,3 +32,4 @@ export * from './tableStateMachine';
 export * from './dealer';
 export * from './bettingEngine';
 export * from './potManager';
+export * from './timerService';

--- a/packages/nextjs/backend/timerService.ts
+++ b/packages/nextjs/backend/timerService.ts
@@ -1,0 +1,121 @@
+import { Player, PlayerAction, PlayerState, Table, Round } from './types';
+import { draw } from './utils';
+
+/** Handlers invoked when timers resolve to auto actions */
+export interface TimerHandlers {
+  onAutoAction: (playerId: string, action: PlayerAction) => void;
+}
+
+/**
+ * TimerService manages per‑action timers, optional timebank consumption,
+ * disconnect grace periods and animation delays between game events.
+ */
+export class TimerService {
+  private turnTimer?: NodeJS.Timeout;
+  private disconnectTimers = new Map<string, NodeJS.Timeout>();
+
+  constructor(
+    private table: Table,
+    private handlers: TimerHandlers,
+    private disconnectGraceMs = 0,
+  ) {}
+
+  /** Clear any active action timer */
+  private clearTurnTimer() {
+    if (this.turnTimer) {
+      clearTimeout(this.turnTimer);
+      this.turnTimer = undefined;
+    }
+  }
+
+  /** Begin countdown for the given player's action */
+  startActionTimer(player: Player) {
+    this.clearTurnTimer();
+
+    const forceAction = () => {
+      const action =
+        this.table.betToCall > 0 ? PlayerAction.FOLD : PlayerAction.CHECK;
+      this.handlers.onAutoAction(player.id, action);
+    };
+
+    // initial per-action timer
+    this.turnTimer = setTimeout(() => {
+      if (player.timebankMs > 0) {
+        const extra = player.timebankMs;
+        player.timebankMs = 0;
+        this.turnTimer = setTimeout(forceAction, extra);
+      } else {
+        forceAction();
+      }
+    }, this.table.actionTimer);
+  }
+
+  /** Handle player disconnection with a grace timer */
+  handleDisconnect(player: Player) {
+    this.clearDisconnectTimer(player.id);
+    const timer = setTimeout(() => {
+      const action =
+        this.table.betToCall > 0 ? PlayerAction.FOLD : PlayerAction.CHECK;
+      this.handlers.onAutoAction(player.id, action);
+      this.disconnectTimers.delete(player.id);
+    }, this.disconnectGraceMs);
+    this.disconnectTimers.set(player.id, timer);
+  }
+
+  /** Clear disconnect timer on reconnection */
+  handleReconnect(playerId: string) {
+    this.clearDisconnectTimer(playerId);
+  }
+
+  private clearDisconnectTimer(id: string) {
+    const timer = this.disconnectTimers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.disconnectTimers.delete(id);
+    }
+  }
+
+  /** Utility: wait for a number of milliseconds */
+  static wait(ms: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+
+  /** Deal hole cards with animation delays */
+  async dealHoleCardsAnimated(table: Table) {
+    if (!table.deck.length) return;
+    const len = table.seats.length;
+    for (let i = 0; i < 2; i++) {
+      for (let offset = 0; offset < len; offset++) {
+        const idx = (table.smallBlindIndex + offset) % len;
+        const player = table.seats[idx];
+        if (player && player.state !== PlayerState.SITTING_OUT) {
+          player.holeCards.push(draw(table.deck));
+          await TimerService.wait(table.dealAnimationDelayMs);
+        }
+      }
+    }
+  }
+
+  /** Deal board cards with animation delays */
+  async dealBoardAnimated(table: Table, round: Round) {
+    if (!table.deck.length) return;
+    // burn card
+    draw(table.deck);
+    await TimerService.wait(table.dealAnimationDelayMs);
+    if (round === Round.FLOP) {
+      for (let i = 0; i < 3; i++) {
+        table.board.push(draw(table.deck));
+        await TimerService.wait(table.dealAnimationDelayMs);
+      }
+    } else if (round === Round.TURN || round === Round.RIVER) {
+      table.board.push(draw(table.deck));
+    }
+  }
+
+  /** Pause between hands after payouts */
+  async interRoundPause() {
+    await TimerService.wait(this.table.interRoundDelayMs);
+  }
+}
+
+export default TimerService;


### PR DESCRIPTION
## Summary
- add TimerService for per-action timers with timebank and disconnect grace
- support deal and inter-round delay helpers
- document timing, timebank, and delay behavior

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module ... not supported)*
- `yarn next:lint` *(fails: eslint-config-next tried to access next, but it isn't declared in its dependencies)*
- `yarn next:check-types` *(fails: numerous missing module and JSX type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c9c5bf33c83249a391168fe09d06b