### PR TITLE
Handle empty stacks and leaving players

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -3,57 +3,62 @@
 The backend exposes strongly typed interfaces that describe the state of a poker table. The key models are defined in `packages/nextjs/backend/types.ts` and are summarised below for reference.
 
 ## Player
+
 Represents a seat at the table.
 
-| Field | Description |
-| --- | --- |
-| `id` | Unique player identifier |
-| `seatIndex` | Seat position in the table array |
-| `stack` | Chips currently available |
-| `state` | One of `EMPTY`, `SEATED`, `SITTING_OUT`, `ACTIVE`, `FOLDED`, `ALL_IN`, `DISCONNECTED`, `LEAVING` |
-| `hasButton` | Player holds the dealer button this hand |
-| `autoPostBlinds` | Automatically post blinds when required |
-| `timebankMs` | Accumulated extra action time in milliseconds |
-| `betThisRound` | Chips committed in the current betting round |
-| `totalCommitted` | Total chips committed across all rounds of the hand |
-| `holeCards` | Up to two face-down cards |
-| `lastAction` | Last action taken: `NONE`, `FOLD`, `CHECK`, `CALL`, `BET`, `RAISE` or `ALL_IN` |
+| Field            | Description                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `id`             | Unique player identifier                                                                         |
+| `seatIndex`      | Seat position in the table array                                                                 |
+| `stack`          | Chips currently available                                                                        |
+| `state`          | One of `EMPTY`, `SEATED`, `SITTING_OUT`, `ACTIVE`, `FOLDED`, `ALL_IN`, `DISCONNECTED`, `LEAVING` |
+| `hasButton`      | Player holds the dealer button this hand                                                         |
+| `autoPostBlinds` | Automatically post blinds when required                                                          |
+| `timebankMs`     | Accumulated extra action time in milliseconds                                                    |
+| `betThisRound`   | Chips committed in the current betting round                                                     |
+| `totalCommitted` | Total chips committed across all rounds of the hand                                              |
+| `holeCards`      | Up to two face-down cards                                                                        |
+| `lastAction`     | Last action taken: `NONE`, `FOLD`, `CHECK`, `CALL`, `BET`, `RAISE` or `ALL_IN`                   |
+
+`SITTING_OUT` players remain seated but are not dealt until they buy in again. `LEAVING` denotes a player scheduled to be removed after the hand.
 
 ## Table
+
 Describes the state of the table for the current hand.
 
-| Field | Description |
-| --- | --- |
-| `seats` | Circular array of `Player \| null` |
-| `buttonIndex` | Seat with the dealer button |
-| `smallBlindIndex` / `bigBlindIndex` | Seats responsible for blinds |
-| `smallBlindAmount` / `bigBlindAmount` | Blind sizes |
-| `minBuyIn` / `maxBuyIn` | Buy‑in limits |
-| `state` | Current `TableState` (`WAITING`, `BLINDS`, `DEALING_HOLE`, `PRE_FLOP`, `FLOP`, `TURN`, `RIVER`, `SHOWDOWN`, `PAYOUT`, `ROTATE`, `CLEANUP`) |
-| `deck` | Remaining cards in the deck |
-| `board` | Community cards on the table |
-| `pots` | Array of `{ amount, eligibleSeatSet }` including side pots |
-| `currentRound` | Betting round (`PREFLOP`, `FLOP`, `TURN`, `RIVER`) |
-| `actingIndex` | Seat whose turn it is or `null` when idle |
-| `betToCall` | Highest commitment to match in the current round |
-| `minRaise` | Minimum raise size per no‑limit rules |
-| `actionTimer` | Default action time in milliseconds |
-| `interRoundDelayMs` / `dealAnimationDelayMs` | Timing helpers for UX |
-| `rakeConfig` | Optional rake percentage, cap and minimum |
+| Field                                        | Description                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `seats`                                      | Circular array of `Player \| null`                                                                                                         |
+| `buttonIndex`                                | Seat with the dealer button                                                                                                                |
+| `smallBlindIndex` / `bigBlindIndex`          | Seats responsible for blinds                                                                                                               |
+| `smallBlindAmount` / `bigBlindAmount`        | Blind sizes                                                                                                                                |
+| `minBuyIn` / `maxBuyIn`                      | Buy‑in limits                                                                                                                              |
+| `state`                                      | Current `TableState` (`WAITING`, `BLINDS`, `DEALING_HOLE`, `PRE_FLOP`, `FLOP`, `TURN`, `RIVER`, `SHOWDOWN`, `PAYOUT`, `ROTATE`, `CLEANUP`) |
+| `deck`                                       | Remaining cards in the deck                                                                                                                |
+| `board`                                      | Community cards on the table                                                                                                               |
+| `pots`                                       | Array of `{ amount, eligibleSeatSet }` including side pots                                                                                 |
+| `currentRound`                               | Betting round (`PREFLOP`, `FLOP`, `TURN`, `RIVER`)                                                                                         |
+| `actingIndex`                                | Seat whose turn it is or `null` when idle                                                                                                  |
+| `betToCall`                                  | Highest commitment to match in the current round                                                                                           |
+| `minRaise`                                   | Minimum raise size per no‑limit rules                                                                                                      |
+| `actionTimer`                                | Default action time in milliseconds                                                                                                        |
+| `interRoundDelayMs` / `dealAnimationDelayMs` | Timing helpers for UX                                                                                                                      |
+| `rakeConfig`                                 | Optional rake percentage, cap and minimum                                                                                                  |
 
 ## HandLog
+
 Immutable record for each completed hand.
 
-| Field | Description |
-| --- | --- |
-| `handId` / `tableId` | Identifiers for the hand and table |
-| `startTs` / `endTs` | Start and end timestamps |
-| `initialStacks` | Player stacks at hand start |
-| `seatMap` | Mapping of seat index to player id |
-| `actions` | Sequence of `{ playerId, round, action, amount, elapsedMs }` |
-| `deckSeed` | Seed or hash for deck permutation |
-| `pots` | Final pot structures including side pots |
-| `winners` | Array of `{ playerId, amount, potIndexes }` |
-| `rake` | Optional rake taken from pots |
+| Field                | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `handId` / `tableId` | Identifiers for the hand and table                           |
+| `startTs` / `endTs`  | Start and end timestamps                                     |
+| `initialStacks`      | Player stacks at hand start                                  |
+| `seatMap`            | Mapping of seat index to player id                           |
+| `actions`            | Sequence of `{ playerId, round, action, amount, elapsedMs }` |
+| `deckSeed`           | Seed or hash for deck permutation                            |
+| `pots`               | Final pot structures including side pots                     |
+| `winners`            | Array of `{ playerId, amount, potIndexes }`                  |
+| `rake`               | Optional rake taken from pots                                |
 
 These definitions provide a consistent contract between the backend engine and any consuming services or clients.

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -108,7 +108,12 @@ During betting:
 
 Disconnection: **ACTIVE** → **DISCONNECTED** (timer); auto-fold when timer expires.
 
-Zero chips after payout: remain **SEATED** but **SITTING_OUT** (or **LEAVING** if user chose to leave).
+End of hand:
+
+- Stack == 0 & re-buy allowed → **SITTING_OUT** until stack ≥ minToPlay.
+- Stack == 0 & no re-buy → **LEAVING** and seat cleared.
+- Voluntary sit-out toggle → **SITTING_OUT** next hand.
+- **LEAVING** during hand → seat becomes **EMPTY**.
 
 ### Table State Machine (per hand)
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -8,20 +8,20 @@ betting rounds progress, see [`dealing-and-betting.md`](./dealing-and-betting.md
 
 ## Core Modules
 
-| Module                   | Responsibility                                                                                                                         |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **TableManager**         | Orchestrates the hand lifecycle and table state machine, moves the dealer button and enforces the minimum number of active players.    |
-| **SeatingManager**       | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions; removes players with zero chips or marks them `SITTING_OUT`. |
-| **BlindManager**         | Assigns the dealer button and blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and manages dead or missed blinds. |
-| **Dealer**               | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server.             |
-| **BettingEngine**        | Manages turn order, validates actions and raise sizes, tracks `betToCall`/`minRaise` and detects round completion.                     |
-| **PotManager**           | Tracks per‑round and total commitments, rebuilds main and side pots on all‑ins, applies rake and settles payouts.                                            |
-| **HandEvaluator**        | Ranks seven‑card hands, resolves ties and supports split pots.                                                                         |
-| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry and provides deal/inter‑round delay helpers. |
-| **EventBus**             | Emits state changes to clients and queues validated commands to the server.                                                            |
-| **Persistence/Audit**    | Records immutable hand and action logs for settlements and anti‑fraud analysis.                                                        |
-| **RulesConfig**          | Defines game parameters such as blinds, rake and buy‑in limits.                                                                        |
-| **Integrity/Anti‑Abuse** | Optional hooks for rate limiting and collusion detection.                                                                              |
+| Module                   | Responsibility                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TableManager**         | Orchestrates the hand lifecycle and table state machine, moves the dealer button and enforces the minimum number of active players.                                                   |
+| **SeatingManager**       | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions; on hand end, removes broke players when re‑buy is disallowed or marks them `SITTING_OUT` until they reload. |
+| **BlindManager**         | Assigns the dealer button and blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and manages dead or missed blinds.                             |
+| **Dealer**               | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server.                                                            |
+| **BettingEngine**        | Manages turn order, validates actions and raise sizes, tracks `betToCall`/`minRaise` and detects round completion.                                                                    |
+| **PotManager**           | Tracks per‑round and total commitments, rebuilds main and side pots on all‑ins, applies rake and settles payouts.                                                                     |
+| **HandEvaluator**        | Ranks seven‑card hands, resolves ties and supports split pots.                                                                                                                        |
+| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry and provides deal/inter‑round delay helpers.                            |
+| **EventBus**             | Emits state changes to clients and queues validated commands to the server.                                                                                                           |
+| **Persistence/Audit**    | Records immutable hand and action logs for settlements and anti‑fraud analysis.                                                                                                       |
+| **RulesConfig**          | Defines game parameters such as blinds, rake and buy‑in limits.                                                                                                                       |
+| **Integrity/Anti‑Abuse** | Optional hooks for rate limiting and collusion detection.                                                                                                                             |
 
 ## Interaction Flow
 

--- a/docs/showdown-payouts.md
+++ b/docs/showdown-payouts.md
@@ -24,4 +24,4 @@ For each pot that still has contenders:
 ## Payout
 
 - Transfer chips from each pot to its winning players and update their stacks.
-- A player reduced to zero chips cannot post blinds on the next hand and is marked `SITTING_OUT` or removed according to table policy.
+- A player reduced to zero chips cannot post blinds on the next hand. If re-buy is allowed, they are marked `SITTING_OUT` and must buy in again before playing. Otherwise they are marked `LEAVING` and their seat is cleared.

--- a/packages/nextjs/backend/playerStateMachine.ts
+++ b/packages/nextjs/backend/playerStateMachine.ts
@@ -1,13 +1,13 @@
-import { PlayerState } from './types';
+import { PlayerState } from "./types";
 
 export type PlayerEvent =
-  | { type: 'NEW_HAND'; stack: number; bigBlind: number; sittingOut: boolean }
-  | { type: 'FOLD' }
-  | { type: 'BET_ALL_IN' }
-  | { type: 'DISCONNECT' }
-  | { type: 'RECONNECT' }
-  | { type: 'STACK_DEPLETED' }
-  | { type: 'LEAVE' };
+  | { type: "NEW_HAND"; stack: number; bigBlind: number; sittingOut: boolean }
+  | { type: "FOLD" }
+  | { type: "BET_ALL_IN" }
+  | { type: "DISCONNECT" }
+  | { type: "RECONNECT" }
+  | { type: "HAND_END"; stack: number; reBuyAllowed: boolean }
+  | { type: "LEAVE" };
 
 /**
  * Reduce player state based on gameplay events.
@@ -18,24 +18,30 @@ export function playerStateReducer(
   event: PlayerEvent,
 ): PlayerState {
   switch (event.type) {
-    case 'NEW_HAND': {
+    case "NEW_HAND": {
       if (event.sittingOut) return PlayerState.SITTING_OUT;
       if (event.stack >= event.bigBlind || event.stack > 0) {
         return PlayerState.ACTIVE;
       }
       return PlayerState.SITTING_OUT;
     }
-    case 'FOLD':
+    case "FOLD":
       return state === PlayerState.ACTIVE ? PlayerState.FOLDED : state;
-    case 'BET_ALL_IN':
+    case "BET_ALL_IN":
       return state === PlayerState.ACTIVE ? PlayerState.ALL_IN : state;
-    case 'DISCONNECT':
+    case "DISCONNECT":
       return state === PlayerState.ACTIVE ? PlayerState.DISCONNECTED : state;
-    case 'RECONNECT':
+    case "RECONNECT":
       return state === PlayerState.DISCONNECTED ? PlayerState.ACTIVE : state;
-    case 'STACK_DEPLETED':
-      return PlayerState.SITTING_OUT;
-    case 'LEAVE':
+    case "HAND_END":
+      if (state === PlayerState.LEAVING) return PlayerState.EMPTY;
+      if (event.stack === 0) {
+        return event.reBuyAllowed
+          ? PlayerState.SITTING_OUT
+          : PlayerState.LEAVING;
+      }
+      return state;
+    case "LEAVE":
       return PlayerState.LEAVING;
     default:
       return state;

--- a/packages/nextjs/backend/tests/playerTableState.test.ts
+++ b/packages/nextjs/backend/tests/playerTableState.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { playerStateReducer } from '../playerStateMachine';
-import { PlayerState, TableState } from '../types';
-import { TableStateMachine } from '../tableStateMachine';
+import { describe, it, expect } from "vitest";
+import { playerStateReducer } from "../playerStateMachine";
+import { PlayerState, TableState } from "../types";
+import { TableStateMachine } from "../tableStateMachine";
 
-describe('playerStateReducer', () => {
-  it('activates player with sufficient stack', () => {
+describe("playerStateReducer", () => {
+  it("activates player with sufficient stack", () => {
     const state = playerStateReducer(PlayerState.SEATED, {
-      type: 'NEW_HAND',
+      type: "NEW_HAND",
       stack: 50,
       bigBlind: 10,
       sittingOut: false,
@@ -14,36 +14,73 @@ describe('playerStateReducer', () => {
     expect(state).toBe(PlayerState.ACTIVE);
   });
 
-  it('folds player on fold action', () => {
-    const state = playerStateReducer(PlayerState.ACTIVE, { type: 'FOLD' });
+  it("sits player out when toggled", () => {
+    const state = playerStateReducer(PlayerState.SEATED, {
+      type: "NEW_HAND",
+      stack: 50,
+      bigBlind: 10,
+      sittingOut: true,
+    });
+    expect(state).toBe(PlayerState.SITTING_OUT);
+  });
+
+  it("folds player on fold action", () => {
+    const state = playerStateReducer(PlayerState.ACTIVE, { type: "FOLD" });
     expect(state).toBe(PlayerState.FOLDED);
+  });
+
+  it("marks player sitting out when broke and rebuy allowed", () => {
+    const state = playerStateReducer(PlayerState.ACTIVE, {
+      type: "HAND_END",
+      stack: 0,
+      reBuyAllowed: true,
+    });
+    expect(state).toBe(PlayerState.SITTING_OUT);
+  });
+
+  it("marks player leaving when broke and rebuy disallowed", () => {
+    const state = playerStateReducer(PlayerState.ACTIVE, {
+      type: "HAND_END",
+      stack: 0,
+      reBuyAllowed: false,
+    });
+    expect(state).toBe(PlayerState.LEAVING);
+  });
+
+  it("removes player who chose to leave", () => {
+    const state = playerStateReducer(PlayerState.LEAVING, {
+      type: "HAND_END",
+      stack: 50,
+      reBuyAllowed: true,
+    });
+    expect(state).toBe(PlayerState.EMPTY);
   });
 });
 
-describe('TableStateMachine', () => {
-  it('progresses through a full hand', () => {
+describe("TableStateMachine", () => {
+  it("progresses through a full hand", () => {
     const sm = new TableStateMachine();
-    sm.dispatch({ type: 'START_HAND', activeSeats: 2 });
+    sm.dispatch({ type: "START_HAND", activeSeats: 2 });
     expect(sm.state).toBe(TableState.BLINDS);
-    sm.dispatch({ type: 'BLINDS_POSTED' });
+    sm.dispatch({ type: "BLINDS_POSTED" });
     expect(sm.state).toBe(TableState.DEALING_HOLE);
-    sm.dispatch({ type: 'DEALING_COMPLETE' });
+    sm.dispatch({ type: "DEALING_COMPLETE" });
     expect(sm.state).toBe(TableState.PRE_FLOP);
-    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    sm.dispatch({ type: "BETTING_COMPLETE", remainingPlayers: 2 });
     expect(sm.state).toBe(TableState.FLOP);
-    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    sm.dispatch({ type: "BETTING_COMPLETE", remainingPlayers: 2 });
     expect(sm.state).toBe(TableState.TURN);
-    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    sm.dispatch({ type: "BETTING_COMPLETE", remainingPlayers: 2 });
     expect(sm.state).toBe(TableState.RIVER);
-    sm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: 2 });
+    sm.dispatch({ type: "BETTING_COMPLETE", remainingPlayers: 2 });
     expect(sm.state).toBe(TableState.SHOWDOWN);
-    sm.dispatch({ type: 'SHOWDOWN_COMPLETE' });
+    sm.dispatch({ type: "SHOWDOWN_COMPLETE" });
     expect(sm.state).toBe(TableState.PAYOUT);
-    sm.dispatch({ type: 'PAYOUT_COMPLETE' });
+    sm.dispatch({ type: "PAYOUT_COMPLETE" });
     expect(sm.state).toBe(TableState.ROTATE);
-    sm.dispatch({ type: 'ROTATION_COMPLETE' });
+    sm.dispatch({ type: "ROTATION_COMPLETE" });
     expect(sm.state).toBe(TableState.CLEANUP);
-    sm.dispatch({ type: 'CLEANUP_COMPLETE', activeSeats: 2 });
+    sm.dispatch({ type: "CLEANUP_COMPLETE", activeSeats: 2 });
     expect(sm.state).toBe(TableState.BLINDS);
   });
 });


### PR DESCRIPTION
## Summary
- add HAND_END event to player state reducer to manage zero-stack, sit-out, and leaving logic
- extend tests for player state transitions
- document table behavior for broke and leaving players

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite/dist/node/index.js not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689cac37ac18832488a5a82a18e5b607