### PR TITLE
Add heads-up utilities and documentation

### DIFF
--- a/docs/heads-up.md
+++ b/docs/heads-up.md
@@ -1,10 +1,12 @@
 # Heads-Up Specifics
 
-When only two players remain in a hand, turn order and blinds differ from multi-way play:
+When only two players remain in a hand, turn order and blinds differ from multi-way play.
 
-- **Button equals Small Blind** – the player on the button posts the small blind.
+## Summary
+
+- **Button = SB** – the player on the button posts the small blind.
 - **Preflop** – the button (small blind) acts first.
 - **Postflop** – the player without the button (big blind) acts first on the flop, turn and river.
-- **Side pots** – side-pot and all-in logic are unchanged.
+- **Side pots** – side-pot and all-in logic remain identical to multi-way play.
 
 These rules are enforced by `BlindManager.assignBlindsAndButton` and `BettingEngine.startBettingRound`.

--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -1,25 +1,20 @@
 import { Table, Player, PlayerState, PlayerAction, Round } from "./types";
 import { recomputePots } from "./potManager";
+import { isHeadsUp } from "./tableUtils";
 
 /** Initialize betting round and determine first to act */
 export function startBettingRound(table: Table, round: Round) {
   table.minRaise = table.bigBlindAmount;
   if (round === Round.PREFLOP) {
     // betToCall already equals big blind from blinds
-    const active = table.seats.filter(
-      (p) => p && p.state === PlayerState.ACTIVE,
-    );
-    if (active.length === 2) {
+    if (isHeadsUp(table)) {
       table.actingIndex = table.smallBlindIndex;
     } else {
       table.actingIndex = nextSeat(table, table.bigBlindIndex);
     }
   } else {
     table.betToCall = 0;
-    const active = table.seats.filter(
-      (p) => p && p.state === PlayerState.ACTIVE,
-    );
-    if (active.length === 2) {
+    if (isHeadsUp(table)) {
       table.actingIndex = table.bigBlindIndex;
     } else {
       table.actingIndex = nextSeat(table, table.buttonIndex);

--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -1,5 +1,6 @@
 import { GameRoom, Table, Player, PlayerState, PlayerAction } from "./types";
 import { recomputePots } from "./potManager";
+import { countActivePlayers, isHeadsUp } from "./tableUtils";
 
 /**
  * BlindManager computes small/big blind positions and posts the blinds.
@@ -83,10 +84,7 @@ export function assignBlindsAndButton(table: Table): boolean {
     return false;
   };
 
-  const activePlayers = table.seats.filter(
-    (p) => p && p.state === PlayerState.ACTIVE,
-  ).length;
-  if (activePlayers < 2) return false;
+  if (countActivePlayers(table) < 2) return false;
 
   const btn = activeSeat(table.buttonIndex + 1);
   if (btn === null) return false;
@@ -99,7 +97,7 @@ export function assignBlindsAndButton(table: Table): boolean {
   let bb: number | null;
 
   const computeBlinds = () => {
-    if (activePlayers === 2) {
+    if (isHeadsUp(table)) {
       sb = btn;
       bb = activeSeat(btn + 1);
     } else {
@@ -121,9 +119,7 @@ export function assignBlindsAndButton(table: Table): boolean {
     if (!sbPosted) sbPlayer.state = PlayerState.SITTING_OUT;
     if (!bbPosted) bbPlayer.state = PlayerState.SITTING_OUT;
 
-    const remaining = table.seats.filter(
-      (p) => p && p.state === PlayerState.ACTIVE,
-    ).length;
+    const remaining = countActivePlayers(table);
     if (remaining < 2) return false;
 
     computeBlinds();
@@ -136,7 +132,7 @@ export function assignBlindsAndButton(table: Table): boolean {
   table.bigBlindIndex = bb;
   table.betToCall = table.bigBlindAmount;
 
-  if (activePlayers === 2) {
+  if (isHeadsUp(table)) {
     table.actingIndex = sb;
   } else {
     const first = activeSeat(bb + 1);

--- a/packages/nextjs/backend/tableUtils.ts
+++ b/packages/nextjs/backend/tableUtils.ts
@@ -1,0 +1,11 @@
+import { Table, PlayerState } from "./types";
+
+/** Count active players at the table */
+export function countActivePlayers(table: Table): number {
+  return table.seats.filter((p) => p && p.state === PlayerState.ACTIVE).length;
+}
+
+/** True when exactly two players remain active */
+export function isHeadsUp(table: Table): boolean {
+  return countActivePlayers(table) === 2;
+}

--- a/packages/nextjs/backend/tests/tableUtils.test.ts
+++ b/packages/nextjs/backend/tests/tableUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { isHeadsUp } from "../tableUtils";
+import {
+  Player,
+  PlayerAction,
+  PlayerState,
+  Table,
+  TableState,
+  Round,
+} from "../types";
+
+const createPlayer = (id: string, seatIndex: number): Player => ({
+  id,
+  seatIndex,
+  stack: 100,
+  state: PlayerState.ACTIVE,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+});
+
+const createTable = (seats: (Player | null)[]): Table => ({
+  seats,
+  buttonIndex: 0,
+  smallBlindIndex: -1,
+  bigBlindIndex: -1,
+  smallBlindAmount: 5,
+  bigBlindAmount: 10,
+  minBuyIn: 0,
+  maxBuyIn: 0,
+  state: TableState.BLINDS,
+  deck: [],
+  board: [],
+  pots: [],
+  currentRound: Round.PREFLOP,
+  actingIndex: null,
+  betToCall: 0,
+  minRaise: 0,
+  actionTimer: 0,
+  interRoundDelayMs: 0,
+  dealAnimationDelayMs: 0,
+});
+
+describe("tableUtils", () => {
+  it("detects heads-up tables", () => {
+    const table = createTable([createPlayer("a", 0), createPlayer("b", 1)]);
+    expect(isHeadsUp(table)).toBe(true);
+    table.seats.push(createPlayer("c", 2));
+    expect(isHeadsUp(table)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize active player counting and heads-up detection
- simplify blind and betting logic by reusing heads-up helpers
- document heads-up rules and add unit test

## Testing
- `yarn format:check` *(fails: Code style issues found in 32 files)*
- `yarn next:lint` *(fails: eslint-config-next missing next dependency)*
- `yarn next:check-types` *(fails: multiple missing module/type errors)*
- `yarn test:nextjs` *(fails: vitest config requires ESM import support)*

------
https://chatgpt.com/codex/tasks/task_e_689cca5e02d88324a86515f9855e5e64