### PR TITLE
Handle zero-stack players and update docs

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -20,7 +20,7 @@ Represents a seat at the table.
 | `holeCards`      | Up to two face-down cards                                                                        |
 | `lastAction`     | Last action taken: `NONE`, `FOLD`, `CHECK`, `CALL`, `BET`, `RAISE` or `ALL_IN`                   |
 
-`SITTING_OUT` players remain seated but are not dealt until they buy in again. `LEAVING` denotes a player scheduled to be removed after the hand.
+`SITTING_OUT` players remain seated but are not dealt until their stack reaches `minToPlay` (big blind by default). `LEAVING` denotes a player scheduled to be removed after the hand.
 
 ## Table
 

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -98,7 +98,7 @@ SEATED → (ACTIVE | SITTING_OUT)
 
 On new hand:
 
-- If stack ≥ BB (or allowed to post short/all-in blind), and not sitting out → **ACTIVE**.
+- If stack ≥ `minToPlay` (≥ BB by default) and not sitting out → **ACTIVE**.
 - Else → **SITTING_OUT**.
 
 During betting:
@@ -110,8 +110,8 @@ Disconnection: **ACTIVE** → **DISCONNECTED** (timer); auto-fold when timer exp
 
 End of hand:
 
-- Stack == 0 & re-buy allowed → **SITTING_OUT** until stack ≥ minToPlay.
-- Stack == 0 & no re-buy → **LEAVING** and seat cleared.
+- Stack == 0 & re-buy allowed → **SITTING_OUT** until stack ≥ `minToPlay`.
+- Stack == 0 & no re-buy → seat cleared immediately.
 - Voluntary sit-out toggle → **SITTING_OUT** next hand.
 - **LEAVING** during hand → seat becomes **EMPTY**.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -8,20 +8,20 @@ betting rounds progress, see [`dealing-and-betting.md`](./dealing-and-betting.md
 
 ## Core Modules
 
-| Module                   | Responsibility                                                                                                                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TableManager**         | Orchestrates the hand lifecycle and table state machine, moves the dealer button and enforces the minimum number of active players.                                                   |
-| **SeatingManager**       | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions; on hand end, removes broke players when re‑buy is disallowed or marks them `SITTING_OUT` until they reload. |
-| **BlindManager**         | Assigns the dealer button and blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and manages dead or missed blinds.                             |
-| **Dealer**               | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server.                                                            |
-| **BettingEngine**        | Manages turn order, validates actions and raise sizes, tracks `betToCall`/`minRaise` and detects round completion.                                                                    |
-| **PotManager**           | Tracks per‑round and total commitments, rebuilds main and side pots on all‑ins, applies rake and settles payouts.                                                                     |
-| **HandEvaluator**        | Ranks seven‑card hands, resolves ties and supports split pots.                                                                                                                        |
-| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry and provides deal/inter‑round delay helpers.                            |
-| **EventBus**             | Emits state changes to clients and queues validated commands to the server.                                                                                                           |
-| **Persistence/Audit**    | Records immutable hand and action logs for settlements and anti‑fraud analysis.                                                                                                       |
-| **RulesConfig**          | Defines game parameters such as blinds, rake and buy‑in limits.                                                                                                                       |
-| **Integrity/Anti‑Abuse** | Optional hooks for rate limiting and collusion detection.                                                                                                                             |
+| Module                   | Responsibility                                                                                                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TableManager**         | Orchestrates the hand lifecycle and table state machine, moves the dealer button and enforces the minimum number of active players.                                                                                             |
+| **SeatingManager**       | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions; on hand end, removes broke players when re‑buy is disallowed or marks them `SITTING_OUT` until they reload to at least `minToPlay` (≥ BB by default). |
+| **BlindManager**         | Assigns the dealer button and blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and manages dead or missed blinds.                                                                       |
+| **Dealer**               | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server.                                                                                                      |
+| **BettingEngine**        | Manages turn order, validates actions and raise sizes, tracks `betToCall`/`minRaise` and detects round completion.                                                                                                              |
+| **PotManager**           | Tracks per‑round and total commitments, rebuilds main and side pots on all‑ins, applies rake and settles payouts.                                                                                                               |
+| **HandEvaluator**        | Ranks seven‑card hands, resolves ties and supports split pots.                                                                                                                                                                  |
+| **TimerService**         | Runs per‑action countdowns with optional timebank and disconnect grace; triggers auto‑fold or check on expiry and provides deal/inter‑round delay helpers.                                                                      |
+| **EventBus**             | Emits state changes to clients and queues validated commands to the server.                                                                                                                                                     |
+| **Persistence/Audit**    | Records immutable hand and action logs for settlements and anti‑fraud analysis.                                                                                                                                                 |
+| **RulesConfig**          | Defines game parameters such as blinds, rake and buy‑in limits.                                                                                                                                                                 |
+| **Integrity/Anti‑Abuse** | Optional hooks for rate limiting and collusion detection.                                                                                                                                                                       |
 
 ## Interaction Flow
 

--- a/docs/showdown-payouts.md
+++ b/docs/showdown-payouts.md
@@ -24,4 +24,4 @@ For each pot that still has contenders:
 ## Payout
 
 - Transfer chips from each pot to its winning players and update their stacks.
-- A player reduced to zero chips cannot post blinds on the next hand. If re-buy is allowed, they are marked `SITTING_OUT` and must buy in again before playing. Otherwise they are marked `LEAVING` and their seat is cleared.
+- A player reduced to zero chips cannot post blinds on the next hand. If re-buy is allowed, they are marked `SITTING_OUT` and must reload to at least the `minToPlay` amount (big blind by default) before being dealt in again. Otherwise their seat is cleared immediately.

--- a/packages/nextjs/backend/tests/playerTableState.test.ts
+++ b/packages/nextjs/backend/tests/playerTableState.test.ts
@@ -14,6 +14,27 @@ describe("playerStateReducer", () => {
     expect(state).toBe(PlayerState.ACTIVE);
   });
 
+  it("sits player out when stack below minToPlay", () => {
+    const state = playerStateReducer(PlayerState.SEATED, {
+      type: "NEW_HAND",
+      stack: 5,
+      bigBlind: 10,
+      sittingOut: false,
+    });
+    expect(state).toBe(PlayerState.SITTING_OUT);
+  });
+
+  it("allows short-buy when minToPlay lower than big blind", () => {
+    const state = playerStateReducer(PlayerState.SEATED, {
+      type: "NEW_HAND",
+      stack: 5,
+      bigBlind: 10,
+      minToPlay: 5,
+      sittingOut: false,
+    });
+    expect(state).toBe(PlayerState.ACTIVE);
+  });
+
   it("sits player out when toggled", () => {
     const state = playerStateReducer(PlayerState.SEATED, {
       type: "NEW_HAND",
@@ -38,13 +59,13 @@ describe("playerStateReducer", () => {
     expect(state).toBe(PlayerState.SITTING_OUT);
   });
 
-  it("marks player leaving when broke and rebuy disallowed", () => {
+  it("removes player when broke and rebuy disallowed", () => {
     const state = playerStateReducer(PlayerState.ACTIVE, {
       type: "HAND_END",
       stack: 0,
       reBuyAllowed: false,
     });
-    expect(state).toBe(PlayerState.LEAVING);
+    expect(state).toBe(PlayerState.EMPTY);
   });
 
   it("removes player who chose to leave", () => {


### PR DESCRIPTION
## Summary
- track `minToPlay` when starting a hand and require stack to meet it before activating players
- clear seats for broke players when re-buy isn't allowed and keep them sitting out otherwise
- document zero-stack, sit-out and leaving behavior across game-state docs

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite from vitest config)*
- `npx prettier packages/nextjs/backend/playerStateMachine.ts packages/nextjs/backend/tests/playerTableState.test.ts docs/showdown-payouts.md docs/modules.md docs/game-states.md docs/data-models.md --check`

------
https://chatgpt.com/codex/tasks/task_e_689ccce41dac8324810d3ec7a6db8290