### PR TITLE
Refine betting round and pot logic

### DIFF
--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -6,7 +6,7 @@ import {
   PlayerAction,
   DeadBlindRule,
 } from "./types";
-import { recomputePots } from "./potManager";
+import { rebuildPots } from "./potManager";
 import { countActivePlayers, isHeadsUp } from "./tableUtils";
 
 /**
@@ -196,7 +196,7 @@ export function assignBlindsAndButton(table: Table): boolean {
     table.seats[sb]?.state === PlayerState.ALL_IN ||
     table.seats[bb]?.state === PlayerState.ALL_IN
   ) {
-    recomputePots(table);
+    rebuildPots(table);
   }
 
   return true;

--- a/packages/nextjs/backend/room.ts
+++ b/packages/nextjs/backend/room.ts
@@ -176,8 +176,15 @@ export function determineWinners(room: GameRoom): PlayerSession[] {
 export function isRoundComplete(room: GameRoom): boolean {
   const active = room.players.filter((p) => !p.hasFolded);
   if (active.length <= 1) return true;
-  const highest = Math.max(...active.map((p) => p.currentBet));
-  return active.every((p) => p.currentBet === highest);
+  if (active.every((p) => p.chips === 0)) return true;
+  const maxBet = Math.max(...active.map((p) => p.currentBet));
+  const allMatched = active.every(
+    (p) => p.chips === 0 || p.currentBet === maxBet,
+  );
+  const canAct = active.some(
+    (p) => p.chips > 0 && p.currentBet < maxBet,
+  );
+  return allMatched && !canAct;
 }
 
 /** Split the pot equally amongst winners */

--- a/packages/nextjs/backend/tests/potAccounting.test.ts
+++ b/packages/nextjs/backend/tests/potAccounting.test.ts
@@ -7,7 +7,7 @@ import {
   TableState,
   Round,
 } from '../types';
-import { recomputePots, applyRake, resetForNextRound } from '../potManager';
+import { rebuildPots, applyRake, resetForNextRound } from '../potManager';
 
 const createPlayer = (
   id: string,
@@ -58,11 +58,10 @@ describe('pot accounting', () => {
       createPlayer('b', 1, 200),
       createPlayer('c', 2, 300),
     ]);
-    recomputePots(table);
+    rebuildPots(table);
     expect(table.pots).toEqual([
       { amount: 300, eligibleSeatSet: [0, 1, 2] },
       { amount: 200, eligibleSeatSet: [1, 2] },
-      { amount: 100, eligibleSeatSet: [2] },
     ]);
   });
 
@@ -72,10 +71,9 @@ describe('pot accounting', () => {
       createPlayer('b', 1, 200),
       createPlayer('c', 2, 100, PlayerState.FOLDED),
     ]);
-    recomputePots(table);
+    rebuildPots(table);
     expect(table.pots).toEqual([
       { amount: 300, eligibleSeatSet: [0, 1] },
-      { amount: 100, eligibleSeatSet: [1] },
     ]);
   });
 
@@ -84,7 +82,7 @@ describe('pot accounting', () => {
       [createPlayer('a', 0, 100), createPlayer('b', 1, 100)],
       { rakeConfig: { percentage: 0.1, cap: 5, min: 0 } },
     );
-    recomputePots(table);
+    rebuildPots(table);
     const total = applyRake(table);
     expect(total).toBe(5);
     expect(table.pots[0].amount).toBe(195);


### PR DESCRIPTION
## Summary
- add rebuildPots for tiered main/side pot calculation
- improve betting round completion checks
- document module interaction flow and validation rules

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite)*
- `yarn next:lint` *(fails: eslint-config-next tried to access next)*
- `yarn format:check` *(warns: code style issues found in 33 files)*

------
https://chatgpt.com/codex/tasks/task_e_689cd2c3d65c8324bdc9601d9fe0878e