### PR TITLE
feat: define networking contract and event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ yarn vercel
 ```
 
 Environment variables such as `NEXT_PUBLIC_PROVIDER_URL` configure Starknet RPC endpoints. The app falls back to `NEXT_PUBLIC_DEVNET_PROVIDER_URL` when the primary endpoint is unavailable.
+
+For details on the WebSocket protocol between clients and the poker server, see [docs/networking-contract.md](docs/networking-contract.md).

--- a/docs/networking-contract.md
+++ b/docs/networking-contract.md
@@ -1,0 +1,39 @@
+# Networking Contract
+
+This document defines the WebSocket protocol between poker clients and the server.
+Commands from the client are idempotent and must include a unique `cmdId`. The
+server ignores duplicates and always replies with the authoritative state.
+
+## Server → Client Events
+
+- `TABLE_SNAPSHOT` – full `Table` state for reconciliation.
+- `HAND_START` – a new hand has begun.
+- `BLINDS_POSTED` – blinds have been applied for the hand.
+- `DEAL_HOLE` – server reveals two cards to the specified `seat`.
+- `ACTION_PROMPT {actingIndex, betToCall, minRaise, timeLeftMs}` – notify the
+  next acting player.
+- `PLAYER_ACTION_APPLIED {playerId, action, amount?}` – a validated action was
+  processed.
+- `ROUND_END {street}` – current betting round completed.
+- `DEAL_FLOP` / `DEAL_TURN` / `DEAL_RIVER` – community cards dealt for each
+  street.
+- `SHOWDOWN {revealOrder}` – order of hand revelation at showdown.
+- `PAYOUT {potBreakdown}` – distribution of the pot(s).
+- `HAND_END` – hand concluded and state will reset shortly.
+- `BUTTON_MOVED {buttonIndex}` – dealer button advanced to the new position.
+- `ERROR {code,msg}` – any recoverable error. Clients should surface the
+  message to the user and resynchronise using the snapshot.
+
+## Client → Server Commands
+
+Every command must carry a `cmdId` field. If the server receives the same
+`cmdId` again it simply resends the latest `TABLE_SNAPSHOT` without applying the
+command.
+
+- `SIT {buyIn}` – take a seat with the provided buy‑in amount.
+- `LEAVE` – vacate the current seat.
+- `SIT_OUT` – mark the player sitting out next hand.
+- `SIT_IN` – return a previously sitting out player to action.
+- `POST_BLIND {type}` – post a small or big blind when prompted.
+- `ACTION {Fold|Check|Call|Bet|Raise|AllIn, amount}` – perform a betting action.
+- `REBUY {amount}` – add chips to the player's stack.

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -1,5 +1,5 @@
-export * from './stateMachine';
-export * from './constants';
+export * from "./stateMachine";
+export * from "./constants";
 export type {
   Suit,
   Rank,
@@ -20,16 +20,17 @@ export type {
   Table,
   HandAction,
   HandLog,
-} from './types';
-export * from './utils';
-export * from './room';
-export * from './hashEvaluator';
-export * from './rng';
-export * from './gameEngine';
-export * from './blindManager';
-export * from './playerStateMachine';
-export * from './tableStateMachine';
-export * from './dealer';
-export * from './bettingEngine';
-export * from './potManager';
-export * from './timerService';
+} from "./types";
+export type { ServerEvent, ClientCommand } from "./networking";
+export * from "./utils";
+export * from "./room";
+export * from "./hashEvaluator";
+export * from "./rng";
+export * from "./gameEngine";
+export * from "./blindManager";
+export * from "./playerStateMachine";
+export * from "./tableStateMachine";
+export * from "./dealer";
+export * from "./bettingEngine";
+export * from "./potManager";
+export * from "./timerService";

--- a/packages/nextjs/backend/networking.ts
+++ b/packages/nextjs/backend/networking.ts
@@ -1,0 +1,50 @@
+import type { Card, Table, PlayerAction, Round } from "./types";
+
+export type ServerEvent =
+  | { type: "TABLE_SNAPSHOT"; table: Table }
+  | { type: "HAND_START" }
+  | { type: "BLINDS_POSTED" }
+  | { type: "DEAL_HOLE"; seat: number; cards: [Card, Card] }
+  | {
+      type: "ACTION_PROMPT";
+      actingIndex: number;
+      betToCall: number;
+      minRaise: number;
+      timeLeftMs: number;
+    }
+  | {
+      type: "PLAYER_ACTION_APPLIED";
+      playerId: string;
+      action: PlayerAction;
+      amount?: number;
+    }
+  | { type: "ROUND_END"; street: Round }
+  | { type: "DEAL_FLOP"; cards: [Card, Card, Card] }
+  | { type: "DEAL_TURN"; card: Card }
+  | { type: "DEAL_RIVER"; card: Card }
+  | { type: "SHOWDOWN"; revealOrder: string[] }
+  | {
+      type: "PAYOUT";
+      potBreakdown: Array<{
+        playerId: string;
+        amount: number;
+        potIndex: number;
+      }>;
+    }
+  | { type: "HAND_END" }
+  | { type: "BUTTON_MOVED"; buttonIndex: number }
+  | { type: "ERROR"; code: string; msg: string };
+
+export type ClientCommand =
+  | { cmdId: string; type: "SIT"; buyIn: number }
+  | { cmdId: string; type: "LEAVE" }
+  | { cmdId: string; type: "SIT_OUT" }
+  | { cmdId: string; type: "SIT_IN" }
+  | { cmdId: string; type: "POST_BLIND"; blind: "SMALL" | "BIG" }
+  | {
+      cmdId: string;
+      type: "ACTION";
+      action: "Fold" | "Check" | "Call" | "Bet" | "Raise" | "AllIn";
+      amount?: number;
+    }
+  | { cmdId: string; type: "REBUY"; amount: number };

--- a/packages/nextjs/server/index.ts
+++ b/packages/nextjs/server/index.ts
@@ -1,6 +1,11 @@
 import { WebSocketServer, WebSocket } from "ws";
 import { createRoom, addPlayer, handleAction, startHand } from "../backend";
-import type { GameRoom } from "../backend";
+import type {
+  GameRoom,
+  ServerEvent,
+  ClientCommand,
+  PlayerAction,
+} from "../backend";
 
 function shortAddress(addr: string): string {
   if (addr.length <= 8) return addr;
@@ -10,9 +15,10 @@ function shortAddress(addr: string): string {
 const wss = new WebSocketServer({ port: 8080 });
 const room: GameRoom = createRoom("default");
 const clients = new Map<WebSocket, string>();
+const processed = new Map<WebSocket, Set<string>>();
 
-function broadcast(data: unknown) {
-  const msg = JSON.stringify(data);
+function broadcast(event: ServerEvent) {
+  const msg = JSON.stringify(event);
   wss.clients.forEach((client) => {
     if (client.readyState === WebSocket.OPEN) client.send(msg);
   });
@@ -21,41 +27,105 @@ function broadcast(data: unknown) {
 wss.on("connection", (ws) => {
   ws.on("message", (data) => {
     try {
-      const msg = JSON.parse(data.toString());
+      const msg: ClientCommand = JSON.parse(data.toString());
+      if (!msg.cmdId) return;
+      let set = processed.get(ws);
+      if (!set) {
+        set = new Set();
+        processed.set(ws, set);
+      }
+      if (set.has(msg.cmdId)) {
+        ws.send(
+          JSON.stringify({
+            type: "TABLE_SNAPSHOT",
+            table: room,
+          } satisfies ServerEvent),
+        );
+        return;
+      }
+      set.add(msg.cmdId);
       switch (msg.type) {
-        case "join": {
-          const address: string = msg.address;
-          const id = address;
-          const nickname = shortAddress(address);
+        case "SIT": {
+          const id = clients.get(ws) ?? msg.cmdId;
+          const nickname = shortAddress(id);
           addPlayer(room, {
             id,
             nickname,
             seat: room.players.length,
-            chips: 1000,
+            chips: msg.buyIn,
           });
           clients.set(ws, id);
-          broadcast({
-            type: "players",
-            players: room.players.map((p) => ({
-              id: p.id,
-              nickname: p.nickname,
-            })),
+          if (room.players.length >= 2 && room.stage === "waiting") {
+            startHand(room);
+            broadcast({ type: "HAND_START" });
+          }
+          broadcast({ type: "TABLE_SNAPSHOT", table: room });
+          break;
+        }
+        case "LEAVE": {
+          const id = clients.get(ws);
+          if (id) {
+            const idx = room.players.findIndex((p) => p.id === id);
+            if (idx !== -1) room.players.splice(idx, 1);
+            clients.delete(ws);
+            broadcast({ type: "TABLE_SNAPSHOT", table: room });
+          }
+          break;
+        }
+        case "ACTION": {
+          const playerId = clients.get(ws);
+          if (!playerId) break;
+          const action: PlayerAction = msg.action.toUpperCase() as PlayerAction;
+          handleAction(room, playerId, {
+            type: action.toLowerCase() as any,
+            amount: msg.amount,
           });
+          broadcast({
+            type: "PLAYER_ACTION_APPLIED",
+            playerId,
+            action,
+            amount: msg.amount,
+          });
+          broadcast({ type: "TABLE_SNAPSHOT", table: room });
           break;
         }
-        case "start": {
-          startHand(room);
-          broadcast({ type: "state", room });
+        case "REBUY": {
+          const playerId = clients.get(ws);
+          if (!playerId) break;
+          const player = room.players.find((p) => p.id === playerId);
+          if (player) player.chips += msg.amount;
+          broadcast({ type: "TABLE_SNAPSHOT", table: room });
           break;
         }
-        case "action": {
-          handleAction(room, msg.playerId, msg.action);
-          broadcast({ type: "state", room });
+        case "SIT_OUT":
+        case "SIT_IN":
+        case "POST_BLIND":
+          ws.send(
+            JSON.stringify({
+              type: "ERROR",
+              code: "UNSUPPORTED",
+              msg: msg.type,
+            } satisfies ServerEvent),
+          );
           break;
-        }
+        default:
+          ws.send(
+            JSON.stringify({
+              type: "ERROR",
+              code: "UNKNOWN_COMMAND",
+              msg: msg.type,
+            } satisfies ServerEvent),
+          );
       }
     } catch (err) {
       console.error("invalid message", err);
+      ws.send(
+        JSON.stringify({
+          type: "ERROR",
+          code: "BAD_JSON",
+          msg: String(err),
+        } satisfies ServerEvent),
+      );
     }
   });
 
@@ -65,10 +135,7 @@ wss.on("connection", (ws) => {
     const idx = room.players.findIndex((p) => p.id === id);
     if (idx !== -1) room.players.splice(idx, 1);
     clients.delete(ws);
-    broadcast({
-      type: "players",
-      players: room.players.map((p) => ({ id: p.id, nickname: p.nickname })),
-    });
+    broadcast({ type: "TABLE_SNAPSHOT", table: room });
   });
 });
 


### PR DESCRIPTION
## Summary
- document websocket networking contract
- add typed server/client message definitions
- enforce idempotent commands in websocket server

## Testing
- `yarn format packages/nextjs/backend/networking.ts packages/nextjs/server/index.ts docs/networking-contract.md README.md` (fails: command not found: scarb)
- `npx prettier -w packages/nextjs/backend/networking.ts packages/nextjs/server/index.ts docs/networking-contract.md README.md`
- `yarn format:check` (fails: command not found: scarb)
- `yarn next:lint` (fails: Failed to load parser './parser.js' declared in '.eslintrc.json » eslint-config-next')
- `yarn next:check-types` (fails: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.)
- `yarn test:nextjs` (fails: require() of ES Module ... not supported)
- `yarn test` (fails: command not found: snforge)


------
https://chatgpt.com/codex/tasks/task_e_689cd9df917483249e39d543d0374f71