### PR TITLE
feat: reset table after hand

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -43,7 +43,7 @@ Describes the state of the table for the current hand.
 | `betToCall` | Highest commitment to match in the current round |
 | `minRaise` | Minimum raise size per no‑limit rules |
 | `actionTimer` | Default action time in milliseconds |
-| `interRoundDelayMs` / `dealAnimationDelayMs` | Timing helpers for UX |
+| `interRoundDelayMs` / `dealAnimationDelayMs` | Delay before starting the next hand / card deal animation timing |
 | `rakeConfig` | Optional rake percentage, cap and minimum |
 | `deadBlindRule` | Strategy for handling missed blinds: `POST` or `WAIT` |
 

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -75,8 +75,8 @@ This document describes the server-side `TableState` lifecycle for a single no-l
 ### 11. **CLEANUP**
 
 - **Entry**: Rotation complete.
-- **Actions**: Board, pots and per-hand metadata are reset.
-- **Exit**: Table returns to **WAITING** for the next hand.
+- **Actions**: Board, pots and per-hand metadata are reset. Players marked **LEAVING** are removed and, if the button seat becomes empty, the button advances to the next active player.
+- **Exit**: If at least two active players can post the blinds, the table waits `interRoundDelayMs` then returns to **BLINDS**. Otherwise it falls back to **WAITING**.
 
 ### **PAUSED** _(optional)_
 

--- a/packages/nextjs/backend/handReset.ts
+++ b/packages/nextjs/backend/handReset.ts
@@ -1,0 +1,76 @@
+import {
+  Table,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from './types';
+import { playerStateReducer } from './playerStateMachine';
+import { advanceButton } from './blindManager';
+import { countActivePlayers } from './tableUtils';
+import TimerService from './timerService';
+
+/**
+ * Reset per-hand table and player fields after a hand finishes and
+ * optionally transition to the next hand if enough players remain.
+ */
+export async function resetTableForNextHand(
+  table: Table,
+  reBuyAllowed = true,
+) {
+  // clear table-level per-hand fields
+  table.deck = [];
+  table.board = [];
+  table.pots = [];
+  table.betToCall = 0;
+  table.minRaise = 0;
+  table.actingIndex = null;
+  table.lastFullRaise = null;
+  table.currentRound = Round.PREFLOP;
+  table.smallBlindIndex = -1;
+  table.bigBlindIndex = -1;
+
+  // reset each seat and remove players marked for leaving
+  table.seats.forEach((player, idx) => {
+    if (!player) return;
+
+    // resolve leaving players and zero stacks
+    let state = playerStateReducer(player.state, {
+      type: 'HAND_END',
+      stack: player.stack,
+      reBuyAllowed,
+    });
+    if (state === PlayerState.EMPTY) {
+      table.seats[idx] = null;
+      return;
+    }
+
+    // set up state for the upcoming hand
+    state = playerStateReducer(state, {
+      type: 'NEW_HAND',
+      stack: player.stack,
+      bigBlind: table.bigBlindAmount,
+      sittingOut: state === PlayerState.SITTING_OUT,
+    });
+    player.state = state;
+
+    // clear per-hand player fields
+    player.holeCards = [];
+    player.betThisRound = 0;
+    player.totalCommitted = 0;
+    player.lastAction = PlayerAction.NONE;
+  });
+
+  // move button in case current seat was removed
+  advanceButton(table);
+
+  const active = countActivePlayers(table);
+  if (active >= 2) {
+    await TimerService.wait(table.interRoundDelayMs);
+    table.state = TableState.BLINDS;
+  } else {
+    table.state = TableState.WAITING;
+  }
+}
+
+export default { resetTableForNextHand };

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -34,3 +34,4 @@ export * from "./dealer";
 export * from "./bettingEngine";
 export * from "./potManager";
 export * from "./timerService";
+export * from "./handReset";

--- a/packages/nextjs/backend/tests/handReset.test.ts
+++ b/packages/nextjs/backend/tests/handReset.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from '../types';
+import { resetTableForNextHand } from '../handReset';
+
+const createPlayer = (
+  id: string,
+  seatIndex: number,
+  stack: number,
+  state: PlayerState = PlayerState.ACTIVE,
+): Player => ({
+  id,
+  seatIndex,
+  stack,
+  state,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: ['X' as any, 'Y' as any],
+  lastAction: PlayerAction.BET,
+  missedSmallBlind: false,
+  missedBigBlind: false,
+});
+
+const createTable = (seats: (Player | null)[]): Table => ({
+  seats,
+  buttonIndex: 0,
+  smallBlindIndex: 0,
+  bigBlindIndex: 1,
+  smallBlindAmount: 5,
+  bigBlindAmount: 10,
+  minBuyIn: 0,
+  maxBuyIn: 0,
+  state: TableState.CLEANUP,
+  deck: ['c'] as any,
+  board: ['b'] as any,
+  pots: [{ amount: 100, eligibleSeatSet: [0, 1] }],
+  currentRound: Round.RIVER,
+  actingIndex: null,
+  betToCall: 20,
+  minRaise: 20,
+  lastFullRaise: null,
+  actionTimer: 0,
+  interRoundDelayMs: 0,
+  dealAnimationDelayMs: 0,
+});
+
+describe('resetTableForNextHand', () => {
+  it('removes leaving players, advances button and starts next hand', async () => {
+    const p1 = createPlayer('a', 0, 100);
+    const p2 = createPlayer('b', 1, 100);
+    const p3 = createPlayer('c', 2, 100, PlayerState.LEAVING);
+    const table = createTable([p1, p2, p3]);
+
+    await resetTableForNextHand(table);
+
+    expect(table.seats[2]).toBeNull();
+    expect(table.buttonIndex).toBe(1);
+    expect(table.state).toBe(TableState.BLINDS);
+    expect(table.board.length).toBe(0);
+    expect(table.pots.length).toBe(0);
+    expect(table.seats[0]?.holeCards.length).toBe(0);
+  });
+
+  it('waits for more players when fewer than two can post', async () => {
+    const p1 = createPlayer('a', 0, 100);
+    const p2 = createPlayer('b', 1, 0);
+    const table = createTable([p1, p2]);
+
+    await resetTableForNextHand(table);
+
+    expect(table.state).toBe(TableState.WAITING);
+  });
+});


### PR DESCRIPTION
## Summary
- add `resetTableForNextHand` to clear per-hand state, remove exiting players, advance button and start next hand after delay
- export hand reset utility
- document cleanup state transition and inter-round delay

## Testing
- `npm run test:nextjs` *(fails: require() of ES Module vite/dist/node/index.js from vitest config)*

------
https://chatgpt.com/codex/tasks/task_e_689d1a401c90832490522f637fed37e0