### PR TITLE
feat: record deck seed in table model

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -36,7 +36,8 @@ Describes the state of the table for the current hand.
 | `minBuyIn` / `maxBuyIn` | Buy‑in limits |
 | `state` | Current `TableState` (`WAITING`, `BLINDS`, `DEALING_HOLE`, `PRE_FLOP`, `FLOP`, `TURN`, `RIVER`, `SHOWDOWN`, `PAYOUT`, `ROTATE`, `CLEANUP`) |
 | `deck` | Remaining cards in the deck |
-| `board` | Community cards on the table |
+| `deckSeed` | Seed or hash used to shuffle the deck |
+| `board` | Community cards on the table (0–5 cards) |
 | `pots` | Array of `{ amount, eligibleSeatSet }` including side pots |
 | `currentRound` | Betting round (`PREFLOP`, `FLOP`, `TURN`, `RIVER`) |
 | `actingIndex` | Seat whose turn it is or `null` when idle |

--- a/packages/nextjs/backend/types.ts
+++ b/packages/nextjs/backend/types.ts
@@ -170,6 +170,8 @@ export interface Table {
   maxBuyIn: number;
   state: TableState;
   deck: Card[];
+  /** Seed used to generate the shuffled deck for this hand */
+  deckSeed?: string;
   board: Card[];
   pots: Pot[];
   currentRound: Round;


### PR DESCRIPTION
## Summary
- track deck shuffle seed in Table model
- document deckSeed and board card count in data model guide

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689d628c56888324bb4f8e0d995e0bcc