### PR TITLE
Add event bus and seating management modules

### DIFF
--- a/packages/nextjs/backend/eventBus.ts
+++ b/packages/nextjs/backend/eventBus.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'events';
+import type { ServerEvent, ClientCommand } from './networking';
+
+/**
+ * Simple event bus broadcasting server events to listeners and queuing
+ * validated client commands for server processing.
+ */
+export class EventBus {
+  private emitter = new EventEmitter();
+  private commandQueue: ClientCommand[] = [];
+
+  /** Emit a server event to all listeners */
+  emit(event: ServerEvent) {
+    this.emitter.emit('event', event);
+  }
+
+  /** Subscribe to server events */
+  onEvent(listener: (event: ServerEvent) => void) {
+    this.emitter.on('event', listener);
+  }
+
+  /** Enqueue a client command for later processing */
+  enqueueCommand(cmd: ClientCommand) {
+    this.commandQueue.push(cmd);
+  }
+
+  /** Dequeue the next pending client command */
+  dequeueCommand(): ClientCommand | undefined {
+    return this.commandQueue.shift();
+  }
+
+  /** Number of queued client commands */
+  get pendingCommands() {
+    return this.commandQueue.length;
+  }
+
+  /** Remove all event listeners */
+  clearListeners() {
+    this.emitter.removeAllListeners('event');
+  }
+}
+
+export default EventBus;

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -28,6 +28,8 @@ export * from "./hashEvaluator";
 export * from "./rng";
 export * from "./gameEngine";
 export * from "./blindManager";
+export * from "./seatingManager";
+export * from "./eventBus";
 export * from "./playerStateMachine";
 export * from "./tableStateMachine";
 export * from "./dealer";

--- a/packages/nextjs/backend/seatingManager.ts
+++ b/packages/nextjs/backend/seatingManager.ts
@@ -1,0 +1,79 @@
+import { Table, Player, PlayerState, PlayerAction } from './types';
+
+/**
+ * SeatingManager handles seat assignment, buy-ins, sit-out/return and leaving.
+ * It also removes players with zero stacks or marks them sitting out when
+ * re-buy is permitted.
+ */
+export class SeatingManager {
+  constructor(private table: Table) {}
+
+  /** Seat a new player at the given index. Returns the created player or null. */
+  seatPlayer(seatIndex: number, id: string, stack: number): Player | null {
+    if (seatIndex < 0 || seatIndex >= this.table.seats.length) return null;
+    if (this.table.seats[seatIndex]) return null;
+    if (stack < this.table.minBuyIn || stack > this.table.maxBuyIn) return null;
+    const player: Player = {
+      id,
+      seatIndex,
+      stack,
+      state: PlayerState.SEATED,
+      hasButton: false,
+      autoPostBlinds: true,
+      timebankMs: 0,
+      betThisRound: 0,
+      totalCommitted: 0,
+      holeCards: [],
+      lastAction: PlayerAction.NONE,
+    };
+    this.table.seats[seatIndex] = player;
+    return player;
+  }
+
+  /** Increase a player's stack up to the table's max buy-in. */
+  topUp(seatIndex: number, amount: number): boolean {
+    const player = this.table.seats[seatIndex];
+    if (!player || amount <= 0) return false;
+    const maxAdd = this.table.maxBuyIn - player.stack;
+    if (amount > maxAdd) return false;
+    player.stack += amount;
+    return true;
+  }
+
+  /** Mark a player as sitting out. */
+  sitOut(seatIndex: number) {
+    const player = this.table.seats[seatIndex];
+    if (player) player.state = PlayerState.SITTING_OUT;
+  }
+
+  /** Return a sitting out player to active play if they have chips. */
+  sitIn(seatIndex: number) {
+    const player = this.table.seats[seatIndex];
+    if (player && player.stack >= this.table.bigBlindAmount) {
+      player.state = PlayerState.ACTIVE;
+    }
+  }
+
+  /** Remove a player entirely from the table. */
+  leave(seatIndex: number) {
+    if (this.table.seats[seatIndex]) {
+      this.table.seats[seatIndex] = null;
+    }
+  }
+
+  /** Remove or mark players with zero chips depending on re-buy rules. */
+  removeBrokePlayers(reBuyAllowed: boolean) {
+    this.table.seats.forEach((p, idx) => {
+      if (!p) return;
+      if (p.stack === 0) {
+        if (reBuyAllowed) {
+          p.state = PlayerState.SITTING_OUT;
+        } else {
+          this.table.seats[idx] = null;
+        }
+      }
+    });
+  }
+}
+
+export default SeatingManager;

--- a/packages/nextjs/backend/tests/eventBus.test.ts
+++ b/packages/nextjs/backend/tests/eventBus.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { EventBus } from '../eventBus';
+import type { ServerEvent, ClientCommand } from '../networking';
+
+describe('EventBus', () => {
+  test('queues commands and emits events', () => {
+    const bus = new EventBus();
+    const received: ServerEvent[] = [];
+    bus.onEvent((e) => received.push(e));
+
+    const ev: ServerEvent = { type: 'HAND_START' };
+    bus.emit(ev);
+    expect(received).toEqual([ev]);
+
+    const cmd: ClientCommand = { cmdId: '1', type: 'SIT', buyIn: 100 };
+    bus.enqueueCommand(cmd);
+    expect(bus.pendingCommands).toBe(1);
+    expect(bus.dequeueCommand()).toEqual(cmd);
+    expect(bus.dequeueCommand()).toBeUndefined();
+  });
+});

--- a/packages/nextjs/backend/tests/seatingManager.test.ts
+++ b/packages/nextjs/backend/tests/seatingManager.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import { SeatingManager } from '../seatingManager';
+import { Table, TableState, Round, PlayerState } from '../types';
+
+function createTable(): Table {
+  return {
+    seats: Array(6).fill(null),
+    buttonIndex: 0,
+    smallBlindIndex: -1,
+    bigBlindIndex: -1,
+    smallBlindAmount: 1,
+    bigBlindAmount: 2,
+    minBuyIn: 20,
+    maxBuyIn: 200,
+    state: TableState.WAITING,
+    deck: [],
+    board: [],
+    pots: [],
+    currentRound: Round.PREFLOP,
+    actingIndex: null,
+    betToCall: 0,
+    minRaise: 0,
+    lastFullRaise: null,
+    actionTimer: 0,
+    interRoundDelayMs: 0,
+    dealAnimationDelayMs: 0,
+  };
+}
+
+describe('SeatingManager', () => {
+  test('seats player and enforces buy-in limits', () => {
+    const table = createTable();
+    const mgr = new SeatingManager(table);
+    const p = mgr.seatPlayer(0, 'p1', 50);
+    expect(p?.stack).toBe(50);
+    expect(mgr.seatPlayer(0, 'p2', 50)).toBeNull();
+    expect(mgr.seatPlayer(1, 'p2', 10)).toBeNull();
+  });
+
+  test('top up and remove broke players', () => {
+    const table = createTable();
+    const mgr = new SeatingManager(table);
+    const p = mgr.seatPlayer(0, 'p1', 50)!;
+    expect(mgr.topUp(0, 160)).toBe(false);
+    expect(mgr.topUp(0, 150)).toBe(true);
+    expect(table.seats[0]?.stack).toBe(200);
+
+    table.seats[0]!.stack = 0;
+    mgr.removeBrokePlayers(false);
+    expect(table.seats[0]).toBeNull();
+
+    const p2 = mgr.seatPlayer(1, 'p2', 40)!;
+    p2.stack = 0;
+    mgr.removeBrokePlayers(true);
+    expect(table.seats[1]?.state).toBe(PlayerState.SITTING_OUT);
+  });
+});


### PR DESCRIPTION
## Summary
- implement EventBus for server-side events and command queueing
- add SeatingManager to handle seat assignment, chip top-ups, and player removal
- export new modules and provide unit tests

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite from vitest config not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689d655d700c83249a01a7b09b4cbbfb