### PR TITLE
Respect auto-post preference and handle blind edge cases

### DIFF
--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -16,7 +16,7 @@ This document describes the server-side `TableState` lifecycle for a single no-l
 - **Entry**: Enough players are seated.
 - **Actions**:
   - Dealer button moves to the next seated player clockwise. In heads-up, the button also posts the small blind.
-  - Small and big blinds are posted (automatically or by prompt).
+  - Small and big blinds are auto-posted for players with `autoPostBlinds` enabled. Short stacks post all-in for their remaining chips while players who decline or lack chips are set to **SITTING_OUT** and blinds are reassigned.
 - **Exit**: Blinds committed by required players.
 - **Edge Cases**: Missing blinds result in the player sitting out or being removed.
 
@@ -154,5 +154,5 @@ End of hand:
 - Attempt to auto-post the small and big blinds:
   - If a stack covers the blind, deduct it and mark the bet for this round.
   - Short stacks may post all-in for their remaining chips.
-- Players unable to post are marked sitting out and blinds are reassigned. Returning players with missed blinds either post them as dead chips or wait for the big blind depending on `deadBlindRule`. If only one player can post, the table returns to **WAITING**.
+- Players who decline auto-posting or lack chips are marked sitting out and flagged for a missed blind. Blinds are reassigned. Returning players with missed blinds either post them as dead chips or wait for the big blind depending on `deadBlindRule`. If only one player can post, the table returns to **WAITING**.
 - Pre-flop action begins left of the big blind, except heads-up where the button acts first and the big blind acts first on later streets.

--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -122,6 +122,7 @@ export function assignBlindsAndButton(table: Table): boolean {
   };
 
   const postBlind = (player: Player, amount: number): boolean => {
+    if (!player.autoPostBlinds) return false;
     collectMissed(player);
     if (player.stack >= amount) {
       player.stack -= amount;
@@ -169,8 +170,14 @@ export function assignBlindsAndButton(table: Table): boolean {
 
     if (sbPosted && bbPosted) break;
 
-    if (!sbPosted) sbPlayer.state = PlayerState.SITTING_OUT;
-    if (!bbPosted) bbPlayer.state = PlayerState.SITTING_OUT;
+    if (!sbPosted) {
+      sbPlayer.state = PlayerState.SITTING_OUT;
+      sbPlayer.missedSmallBlind = true;
+    }
+    if (!bbPosted) {
+      bbPlayer.state = PlayerState.SITTING_OUT;
+      bbPlayer.missedBigBlind = true;
+    }
 
     const remaining = countActivePlayers(table);
     if (remaining < 2) return false;

--- a/packages/nextjs/backend/tests/blindsTable.test.ts
+++ b/packages/nextjs/backend/tests/blindsTable.test.ts
@@ -248,4 +248,106 @@ describe("assignBlindsAndButton", () => {
     expect(table.seats[2]?.betThisRound).toBe(20);
     expect(table.seats[2]?.missedBigBlind).toBe(false);
   });
+
+  it("allows short stacks to post all-in blinds", () => {
+    const table: Table = {
+      seats: [createPlayer("a", 0, 3), createPlayer("b", 1, 6)],
+      buttonIndex: 1,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      lastFullRaise: null,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+
+    advanceButton(table);
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    expect(table.seats[0]?.state).toBe(PlayerState.ALL_IN);
+    expect(table.seats[0]?.betThisRound).toBe(3);
+    expect(table.seats[1]?.state).toBe(PlayerState.ALL_IN);
+    expect(table.seats[1]?.betThisRound).toBe(6);
+  });
+
+  it("marks players sitting out when they decline to auto-post", () => {
+    const table: Table = {
+      seats: [
+        createPlayer("a", 0, 100),
+        createPlayer("b", 1, 100),
+        createPlayer("c", 2, 100),
+      ],
+      buttonIndex: 0,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      lastFullRaise: null,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+    table.seats[2]!.autoPostBlinds = false;
+    advanceButton(table);
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(true);
+    expect(table.seats[2]?.state).toBe(PlayerState.SITTING_OUT);
+    expect(table.seats[2]?.missedSmallBlind).toBe(true);
+    expect(table.smallBlindIndex).toBe(1);
+    expect(table.bigBlindIndex).toBe(0);
+    expect(table.actingIndex).toBe(1);
+  });
+
+  it("returns false when only one player can post a blind", () => {
+    const table: Table = {
+      seats: [createPlayer("a", 0, 100), createPlayer("b", 1, 0)],
+      buttonIndex: 1,
+      smallBlindIndex: -1,
+      bigBlindIndex: -1,
+      smallBlindAmount: 5,
+      bigBlindAmount: 10,
+      minBuyIn: 0,
+      maxBuyIn: 0,
+      state: TableState.BLINDS,
+      deck: [],
+      board: [],
+      pots: [],
+      currentRound: Round.PREFLOP,
+      actingIndex: null,
+      betToCall: 0,
+      minRaise: 0,
+      lastFullRaise: null,
+      actionTimer: 0,
+      interRoundDelayMs: 0,
+      dealAnimationDelayMs: 0,
+    };
+    table.seats[0]!.autoPostBlinds = false;
+    advanceButton(table);
+    const ok = assignBlindsAndButton(table);
+    expect(ok).toBe(false);
+    expect(table.seats[0]?.state).toBe(PlayerState.SITTING_OUT);
+    expect(table.seats[0]?.missedSmallBlind).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- honor players' `autoPostBlinds` setting when assigning blinds
- mark missed blind and sit out players who decline posting
- document blind auto-post/all-in behavior and expand test coverage

## Testing
- `NODE_OPTIONS=--experimental-vm-modules yarn test:nextjs` *(fails: require() of ES Module ...)*
- `yarn workspace @ss-2/nextjs format:check`


------
https://chatgpt.com/codex/tasks/task_e_689d691eb7048324b9b3c046aa4bb9d3