### PR TITLE
Reset betting round state and refine dealing logic

### DIFF
--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -1,5 +1,5 @@
 import { Table, Player, PlayerState, PlayerAction, Round } from "./types";
-import { rebuildPots } from "./potManager";
+import { rebuildPots, resetForNextRound } from "./potManager";
 import { isHeadsUp } from "./tableUtils";
 
 /** Initialize betting round and determine first to act */
@@ -14,7 +14,7 @@ export function startBettingRound(table: Table, round: Round) {
       table.actingIndex = nextSeat(table, table.bigBlindIndex);
     }
   } else {
-    table.betToCall = 0;
+    resetForNextRound(table);
     if (isHeadsUp(table)) {
       table.actingIndex = table.bigBlindIndex;
     } else {

--- a/packages/nextjs/backend/dealer.ts
+++ b/packages/nextjs/backend/dealer.ts
@@ -10,18 +10,18 @@ export function dealHoleCards(table: Table) {
     for (let offset = 0; offset < len; offset++) {
       const idx = (table.smallBlindIndex + offset) % len;
       const player = table.seats[idx];
-      if (player && player.state !== PlayerState.SITTING_OUT) {
+      if (player && player.state === PlayerState.ACTIVE) {
         player.holeCards.push(draw(table.deck));
       }
     }
   }
 }
 
-/** Deal board cards for the given round with optional burn */
-export function dealBoard(table: Table, round: Round) {
+/** Deal board cards for the given round */
+export function dealBoard(table: Table, round: Round, burn = true) {
   if (!table.deck.length) return;
-  // burn card
-  draw(table.deck);
+  // optional burn card
+  if (burn) draw(table.deck);
   if (round === Round.FLOP) {
     table.board.push(draw(table.deck), draw(table.deck), draw(table.deck));
   } else if (round === Round.TURN || round === Round.RIVER) {


### PR DESCRIPTION
## Summary
- ensure hole cards are dealt only to active seats and allow optional burn when dealing board
- reset per-round bets and commitments when starting post-flop betting rounds

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module from vitest config not supported)*
- `yarn next:check-types` *(fails: numerous TS2307 and TS7026 errors for missing modules and JSX types)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ac71ffc8324a3c76f6a348ff5a6