### PR TITLE
refactor: ignore zero thresholds in pot rebuild

### DIFF
--- a/packages/nextjs/backend/potManager.ts
+++ b/packages/nextjs/backend/potManager.ts
@@ -12,9 +12,12 @@ export function rebuildPots(table: Table) {
     return;
   }
 
-  const thresholds = Array.from(new Set(players.map((p) => p.totalCommitted))).sort(
-    (a, b) => a - b,
-  );
+  // Build sorted unique commitment thresholds, ignoring zero as it cannot
+  // contribute to a pot. Each threshold represents a layer of chips that at
+  // least one player has contributed.
+  const thresholds = Array.from(
+    new Set(players.map((p) => p.totalCommitted).filter((t) => t > 0)),
+  ).sort((a, b) => a - b);
 
   let previous = 0;
   const pots: Pot[] = [];


### PR DESCRIPTION
## Summary
- ignore zero chip commitments when rebuilding pots to avoid unnecessary tiers

## Testing
- `npm test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_689d70c38c1c832487aafbdd39730aa1