### PR TITLE
feat: add hand lifecycle helpers

### DIFF
--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -135,11 +135,15 @@ End of hand:
 
 - At least two active players who can post blinds or are allowed to post all-in blinds.
 - Button assigned to the next active seat from the previous hand; for the first hand, choose a random active seat.
+- The `startHand` helper posts blinds, shuffles a fresh deck and deals two
+  hole cards to each active seat. If blinds cannot be posted the table falls
+  back to **WAITING**.
 
 ### End Conditions
 
 - If all but one player fold, the remaining player immediately receives the entire pot or pots.
 - After a showdown, payouts are completed based on hand evaluation.
+- The `endHand` helper awards chips and resets state before the next hand.
 
 ### Cleanup
 

--- a/packages/nextjs/backend/handLifecycle.ts
+++ b/packages/nextjs/backend/handLifecycle.ts
@@ -1,0 +1,55 @@
+import { Table, TableState, Round, PlayerState } from './types';
+import { assignBlindsAndButton } from './blindManager';
+import { dealDeck } from './utils';
+import { dealHoleCards } from './dealer';
+import { rebuildPots, awardPots } from './potManager';
+import { resetTableForNextHand } from './handReset';
+import { countActivePlayers } from './tableUtils';
+
+/**
+ * Attempt to start a new hand by posting blinds, shuffling and
+ * dealing hole cards. Returns `true` on success, otherwise
+ * `false` when the hand cannot begin (e.g. not enough active
+ * players or blinds could not be posted).
+ */
+export function startHand(table: Table): boolean {
+  if (table.state !== TableState.BLINDS) return false;
+  if (countActivePlayers(table) < 2) {
+    table.state = TableState.WAITING;
+    return false;
+  }
+  if (!assignBlindsAndButton(table)) {
+    table.state = TableState.WAITING;
+    return false;
+  }
+  table.deck = dealDeck();
+  table.board = [];
+  table.pots = [];
+  table.currentRound = Round.PREFLOP;
+  dealHoleCards(table);
+  table.state = TableState.PRE_FLOP;
+  return true;
+}
+
+/**
+ * Resolve the current hand by awarding pots or, if only a single
+ * player remains, giving them the entire pot. Afterwards the table
+ * is reset for the next hand or returned to the waiting state.
+ */
+export async function endHand(table: Table) {
+  const live = table.seats.filter(
+    (p): p is NonNullable<typeof p> => !!p && p.state !== PlayerState.FOLDED,
+  );
+  rebuildPots(table);
+  if (live.length === 1) {
+    const total = table.pots.reduce((sum, p) => sum + p.amount, 0);
+    live[0].stack += total;
+    table.pots = [];
+  } else if (live.length > 1) {
+    awardPots(table);
+  }
+  table.state = TableState.PAYOUT;
+  await resetTableForNextHand(table);
+}
+
+export default { startHand, endHand };

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -37,3 +37,4 @@ export * from "./bettingEngine";
 export * from "./potManager";
 export * from "./timerService";
 export * from "./handReset";
+export * from "./handLifecycle";

--- a/packages/nextjs/backend/tests/handLifecycle.test.ts
+++ b/packages/nextjs/backend/tests/handLifecycle.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { startHand, endHand } from '../handLifecycle';
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from '../types';
+
+const createPlayer = (
+  id: string,
+  seatIndex: number,
+  stack: number,
+): Player => ({
+  id,
+  seatIndex,
+  stack,
+  state: PlayerState.ACTIVE,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+  missedSmallBlind: false,
+  missedBigBlind: false,
+});
+
+const createTable = (seats: (Player | null)[]): Table => ({
+  seats,
+  buttonIndex: 0,
+  smallBlindIndex: -1,
+  bigBlindIndex: -1,
+  smallBlindAmount: 5,
+  bigBlindAmount: 10,
+  minBuyIn: 0,
+  maxBuyIn: 0,
+  state: TableState.BLINDS,
+  deck: [],
+  board: [],
+  pots: [],
+  currentRound: Round.PREFLOP,
+  actingIndex: null,
+  betToCall: 0,
+  minRaise: 0,
+  lastFullRaise: null,
+  actionTimer: 0,
+  interRoundDelayMs: 0,
+  dealAnimationDelayMs: 0,
+});
+
+describe('handLifecycle', () => {
+  it('starts a hand when blinds can be posted', () => {
+    const table = createTable([
+      createPlayer('a', 0, 100),
+      createPlayer('b', 1, 100),
+    ]);
+    const ok = startHand(table);
+    expect(ok).toBe(true);
+    expect(table.state).toBe(TableState.PRE_FLOP);
+    expect(table.seats[0]?.holeCards.length).toBe(2);
+    expect(table.seats[1]?.betThisRound).toBeGreaterThan(0);
+  });
+
+  it('awards pot to last player and resets table', async () => {
+    const p1 = createPlayer('a', 0, 90);
+    const p2 = createPlayer('b', 1, 90);
+    p1.totalCommitted = 10;
+    p2.totalCommitted = 10;
+    p2.state = PlayerState.FOLDED;
+    const table = createTable([p1, p2]);
+    table.pots = [{ amount: 20, eligibleSeatSet: [0, 1] }];
+    await endHand(table);
+    expect(p1.stack).toBe(110);
+    expect(table.pots.length).toBe(0);
+    expect(table.state).toBe(TableState.BLINDS);
+  });
+});


### PR DESCRIPTION
## Summary
- add startHand and endHand helpers for hand lifecycle
- document hand start/end process and link helpers
- export helpers and add unit coverage

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d5e85548324a61886c00b95598d