### PR TITLE
feat: reposition dealer window

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -83,7 +83,7 @@ export default function PlayPage() {
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} />
       </div>
-      <div className="fixed bottom-4 right-4">
+      <div id="action-buttons" className="fixed bottom-4 right-4">
         <ActionBar
           street={stageNames[street] ?? "preflop"}
           onActivate={handleActivate}

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -1,9 +1,19 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useGameStore } from "../hooks/useGameStore";
 
 export default function DealerWindow() {
   const logs = useGameStore((s) => s.logs);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [top, setTop] = useState(0);
+
+  const updatePosition = useCallback(() => {
+    const el = containerRef.current;
+    const actions = document.getElementById("action-buttons");
+    if (el && actions) {
+      const actionTop = actions.getBoundingClientRect().top;
+      setTop(Math.max(actionTop - el.offsetHeight - 8, 0));
+    }
+  }, []);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -11,12 +21,20 @@ export default function DealerWindow() {
       el.scrollTop = el.scrollHeight;
       el.scrollLeft = el.scrollWidth;
     }
-  }, [logs]);
+    updatePosition();
+  }, [logs, updatePosition]);
+
+  useEffect(() => {
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    return () => window.removeEventListener("resize", updatePosition);
+  }, [updatePosition]);
 
   return (
     <div
       ref={containerRef}
-      className="fixed left-4 bottom-4 w-64 bg-black/50 text-white rounded text-xs flex flex-row flex-nowrap space-x-2 overflow-x-auto overflow-y-hidden h-5 p-1 md:top-[60%] md:bottom-auto md:h-40 md:p-2 md:flex-col md:justify-end md:space-y-1 md:space-x-0 md:overflow-y-auto md:overflow-x-hidden"
+      style={{ top }}
+      className="fixed left-4 w-64 bg-black/50 text-white rounded text-xs flex flex-row flex-nowrap space-x-2 overflow-x-auto overflow-y-hidden h-5 p-1 md:h-40 md:p-2 md:flex-col md:justify-end md:space-y-1 md:space-x-0 md:overflow-y-auto md:overflow-x-hidden"
     >
       {logs.map((msg, i) => (
         <div key={i} className="whitespace-nowrap">


### PR DESCRIPTION
## Summary
- keep dealer info window above action buttons
- collapse dealer log to single-line on small screens

## Testing
- `yarn workspace @ss-2/nextjs format`
- `yarn next:lint` *(fails: eslint-config-next missing next dependency)*
- `yarn test:nextjs` *(fails: require() of ES module vite from vitest config)*
- `yarn next:check-types` *(fails: multiple missing module/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d7eb0861c832497ade23626185be4