### PR TITLE
Clarify heads-up betting order

### DIFF
--- a/docs/dealing-and-betting.md
+++ b/docs/dealing-and-betting.md
@@ -17,6 +17,8 @@ Between individual deal events the server pauses `dealAnimationDelayMs` millisec
 - **Preflop**: the first active player to the left of the big blind acts first. In heads‑up play the small blind acts first.
 - **Flop / Turn / River**: the first active player to the left of the button acts first. In heads‑up play the big blind acts first.
 
+- **Side pots**: when heads‑up, side‑pot construction and all‑in handling work the same as in multi‑way pots.
+
 See [Heads-Up Specifics](./heads-up.md) for a concise summary of the two-player rules.
 
 ## Legal Actions

--- a/docs/heads-up.md
+++ b/docs/heads-up.md
@@ -5,8 +5,8 @@ When only two players remain in a hand, turn order and blinds differ from multi-
 ## Summary
 
 - **Button = SB** – the player on the button posts the small blind.
-- **Preflop** – the button (small blind) acts first.
-- **Postflop** – the player without the button (big blind) acts first on the flop, turn and river.
-- **Side pots** – side-pot and all-in logic remain identical to multi-way play.
+- **Preflop** – the small blind on the button acts first.
+- **Postflop** – the player without the button (big blind) acts first.
+- **Side pots** – side‑pot logic remains identical to multi‑way play.
 
 These rules are enforced by `BlindManager.assignBlindsAndButton` and `BettingEngine.startBettingRound`.

--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -9,6 +9,7 @@ export function startBettingRound(table: Table, round: Round) {
   if (round === Round.PREFLOP) {
     // betToCall already equals big blind from blinds
     if (isHeadsUp(table)) {
+      // Heads-up preflop: the button posts the small blind and acts first.
       table.actingIndex = table.smallBlindIndex;
     } else {
       table.actingIndex = nextSeat(table, table.bigBlindIndex);
@@ -16,6 +17,7 @@ export function startBettingRound(table: Table, round: Round) {
   } else {
     resetForNextRound(table);
     if (isHeadsUp(table)) {
+      // Heads-up postflop: the player without the button (big blind) acts first.
       table.actingIndex = table.bigBlindIndex;
     } else {
       table.actingIndex = nextSeat(table, table.buttonIndex);
@@ -106,7 +108,10 @@ export function applyAction(
       break;
     }
     case PlayerAction.ALL_IN: {
-      if (table.lastFullRaise === seatIndex && player.betThisRound < table.betToCall)
+      if (
+        table.lastFullRaise === seatIndex &&
+        player.betThisRound < table.betToCall
+      )
         throw new Error("action not reopened");
       const commit = player.stack;
       player.stack = 0;

--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -152,6 +152,8 @@ export function assignBlindsAndButton(table: Table): boolean {
 
   const computeBlinds = () => {
     if (isHeadsUp(table)) {
+      // Heads-up: the button also posts the small blind and the
+      // opposing seat posts the big blind.
       sb = btn;
       bb = activeSeat(btn + 1, "BB");
     } else {
@@ -193,6 +195,7 @@ export function assignBlindsAndButton(table: Table): boolean {
   table.betToCall = table.bigBlindAmount;
 
   if (isHeadsUp(table)) {
+    // Preflop in heads-up: small blind (on the button) acts first.
     table.actingIndex = sb;
   } else {
     const first = activeSeat(bb + 1, "BB");


### PR DESCRIPTION
## Summary
- document heads-up acting order and side-pot behavior
- comment blind and betting engines for heads-up logic

## Testing
- `yarn format:check` *(fails: Code style issues found in 41 files)*
- `yarn next:lint` *(fails: Failed to load parser './parser.js')*
- `yarn next:check-types` *(fails: Cannot find module '@starknet-react/core' etc.)*
- `yarn test:nextjs` *(fails: require() of ES module vite from vitest config)*
- `yarn test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_689d7f9802648324abad284c1b1a83af