### PR TITLE
Rotate dealer button after payouts and document dead blind options

### DIFF
--- a/docs/dealing-and-betting.md
+++ b/docs/dealing-and-betting.md
@@ -87,5 +87,6 @@ function rebuildPots():
 - When a player's `actionTimer` (typically around 15s) expires, they automatically check if `betToCall` is `0` or fold otherwise.
 - The server processes actions sequentially and ignores out-of-turn commands.
 - When a player disconnects during their turn, a separate grace timer runs. When it elapses the player's remaining `timebankMs` is consumed before an automatic fold or check is applied.
+- After payouts the dealer button moves to the next active seat clockwise. Players returning from sitting out must either post any missed blinds immediately (`deadBlindRule = POST`) or wait for the big blind to reach them (`deadBlindRule = WAIT`). When the small-blind seat is empty the blinds roll forward to the next available active players.
 - After payouts the table waits `interRoundDelayMs` before the next hand begins.
 - In heads-up play the button posts the small blind, the opposing player posts the big blind, and acting order follows those positions.

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -70,13 +70,15 @@ This document describes the server-side `TableState` lifecycle for a single no-l
 ### 10. **ROTATE**
 
 - **Entry**: Payout complete.
-- **Actions**: Dealer button and blinds move to the next eligible players.
+- **Actions**: Dealer button moves to the next active seat clockwise. Returning players who missed blinds must either post the
+  big blind (and small blind if required) immediately (`deadBlindRule = POST`) or wait for the big blind to reach them
+  (`deadBlindRule = WAIT`). If the small-blind seat is empty, blinds roll forward to the next available active seats.
 - **Exit**: Rotation finished.
 
 ### 11. **CLEANUP**
 
 - **Entry**: Rotation complete.
-- **Actions**: Board, pots and per-hand metadata are reset. Players marked **LEAVING** are removed and, if the button seat becomes empty, the button advances to the next active player.
+- **Actions**: Board, pots and per-hand metadata are reset. Players marked **LEAVING** are removed.
 - **Exit**: If at least two active players can post the blinds, the table waits `interRoundDelayMs` then returns to **BLINDS**. Otherwise it falls back to **WAITING**.
 
 ### **PAUSED** _(optional)_

--- a/packages/nextjs/backend/handReset.ts
+++ b/packages/nextjs/backend/handReset.ts
@@ -18,18 +18,6 @@ export async function resetTableForNextHand(
   table: Table,
   reBuyAllowed = true,
 ) {
-  // clear table-level per-hand fields
-  table.deck = [];
-  table.board = [];
-  table.pots = [];
-  table.betToCall = 0;
-  table.minRaise = 0;
-  table.actingIndex = null;
-  table.lastFullRaise = null;
-  table.currentRound = Round.PREFLOP;
-  table.smallBlindIndex = -1;
-  table.bigBlindIndex = -1;
-
   // reset each seat and remove players marked for leaving
   table.seats.forEach((player, idx) => {
     if (!player) return;
@@ -64,6 +52,18 @@ export async function resetTableForNextHand(
 
   // move button in case current seat was removed
   advanceButton(table);
+
+  // clear table-level per-hand fields
+  table.deck = [];
+  table.board = [];
+  table.pots = [];
+  table.betToCall = 0;
+  table.minRaise = 0;
+  table.actingIndex = null;
+  table.lastFullRaise = null;
+  table.currentRound = Round.PREFLOP;
+  table.smallBlindIndex = -1;
+  table.bigBlindIndex = -1;
 
   const active = countActivePlayers(table);
   if (active >= 2) {

--- a/packages/nextjs/backend/tests/handLifecycle.test.ts
+++ b/packages/nextjs/backend/tests/handLifecycle.test.ts
@@ -77,5 +77,6 @@ describe('handLifecycle', () => {
     expect(p1.stack).toBe(110);
     expect(table.pots.length).toBe(0);
     expect(table.state).toBe(TableState.BLINDS);
+    expect(table.buttonIndex).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- rotate dealer button before clearing state so it always advances after payouts
- describe dead blind handling and button rotation in the docs
- test that button moves forward when a hand ends

## Testing
- `yarn test:nextjs` *(fails: require() of ES Module vite/dist/node/index.js from vitest config not supported)*
- `yarn format:check` *(warns: Code style issues found in 41 files)*

------
https://chatgpt.com/codex/tasks/task_e_689d85f05a008324871701253aeeab03