### PR TITLE
Anchor dealer info window below table

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -83,7 +83,10 @@ export default function PlayPage() {
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} />
       </div>
-      <div id="action-buttons" className="fixed bottom-4 right-4">
+      <div id="dealer-anchor" className="relative w-full h-px">
+        <DealerWindow />
+      </div>
+      <div id="action-buttons" className="flex justify-end p-4">
         <ActionBar
           street={stageNames[street] ?? "preflop"}
           onActivate={handleActivate}
@@ -93,7 +96,6 @@ export default function PlayPage() {
           hasHandStarted={handStarted}
         />
       </div>
-      <DealerWindow />
     </main>
   );
 }

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -1,42 +1,42 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useGameStore } from "../hooks/useGameStore";
 
 export default function DealerWindow() {
   const logs = useGameStore((s) => s.logs);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [top, setTop] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
-  const updatePosition = useCallback(() => {
-    const el = containerRef.current;
-    const actions = document.getElementById("action-buttons");
-    if (el && actions) {
-      const actionTop = actions.getBoundingClientRect().top;
-      setTop(Math.max(actionTop - el.offsetHeight - 8, 0));
-    }
+  useEffect(() => {
+    const handle = () => setIsMobile(window.innerWidth < 640);
+    handle();
+    window.addEventListener("resize", handle);
+    return () => window.removeEventListener("resize", handle);
   }, []);
 
   useEffect(() => {
+    if (isMobile && !expanded) return;
     const el = containerRef.current;
     if (el) {
       el.scrollTop = el.scrollHeight;
       el.scrollLeft = el.scrollWidth;
     }
-    updatePosition();
-  }, [logs, updatePosition]);
+  }, [logs, isMobile, expanded]);
 
-  useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    return () => window.removeEventListener("resize", updatePosition);
-  }, [updatePosition]);
+  const displayLogs = isMobile && !expanded ? logs.slice(-1) : logs;
+
+  const base = "absolute left-4 w-64 bg-black/50 text-white rounded text-xs";
+  const collapsed = "h-5 p-1 overflow-hidden cursor-pointer flex items-center";
+  const open =
+    "max-h-40 p-2 overflow-y-auto flex flex-col justify-end space-y-1";
 
   return (
     <div
       ref={containerRef}
-      style={{ top }}
-      className="fixed left-4 w-64 bg-black/50 text-white rounded text-xs flex flex-row flex-nowrap space-x-2 overflow-x-auto overflow-y-hidden h-5 p-1 md:h-40 md:p-2 md:flex-col md:justify-end md:space-y-1 md:space-x-0 md:overflow-y-auto md:overflow-x-hidden"
+      className={`${base} ${isMobile && !expanded ? collapsed : open}`}
+      onClick={() => isMobile && setExpanded((e) => !e)}
     >
-      {logs.map((msg, i) => (
+      {displayLogs.map((msg, i) => (
         <div key={i} className="whitespace-nowrap">
           {msg}
         </div>


### PR DESCRIPTION
## Summary
- Anchor dealer log window to a 1px divider between table and action buttons
- Collapse dealer log to a single line on small screens with tap-to-expand

## Testing
- ⚠️ `yarn next:lint` *(failed: eslint-config-next missing dependency)*
- ⚠️ `yarn test:nextjs` *(failed: vitest startup error require ES module)*

------
https://chatgpt.com/codex/tasks/task_e_689d87651da083248726327acfd9a74d