### PR TITLE
Start betting round on hand start and clarify module flow

### DIFF
--- a/docs/dealing-and-betting.md
+++ b/docs/dealing-and-betting.md
@@ -74,8 +74,7 @@ function rebuildPots():
     tierContribPlayers = live.filter(p => p.totalCommitted >= t)
     if tierContribPlayers.length >= 2 and t > prev:
       amount = (t - prev) * tierContribPlayers.length
-  pots.push({ amountAccumulated += amount,
-                  eligible: set(tierContribPlayers.map(p => p.seatIndex)) })
+      pots.push({ amount, eligible: set(tierContribPlayers.map(p => p.seatIndex)) })
       prev = t
 ```
 

--- a/packages/nextjs/backend/handLifecycle.ts
+++ b/packages/nextjs/backend/handLifecycle.ts
@@ -1,10 +1,11 @@
-import { Table, TableState, Round, PlayerState } from './types';
-import { assignBlindsAndButton } from './blindManager';
-import { dealDeck } from './utils';
-import { dealHoleCards } from './dealer';
-import { rebuildPots, awardPots } from './potManager';
-import { resetTableForNextHand } from './handReset';
-import { countActivePlayers } from './tableUtils';
+import { Table, TableState, Round, PlayerState } from "./types";
+import { assignBlindsAndButton } from "./blindManager";
+import { dealDeck } from "./utils";
+import { dealHoleCards } from "./dealer";
+import { rebuildPots, awardPots } from "./potManager";
+import { startBettingRound } from "./bettingEngine";
+import { resetTableForNextHand } from "./handReset";
+import { countActivePlayers } from "./tableUtils";
 
 /**
  * Attempt to start a new hand by posting blinds, shuffling and
@@ -27,6 +28,7 @@ export function startHand(table: Table): boolean {
   table.pots = [];
   table.currentRound = Round.PREFLOP;
   dealHoleCards(table);
+  startBettingRound(table, Round.PREFLOP);
   table.state = TableState.PRE_FLOP;
   return true;
 }


### PR DESCRIPTION
## Summary
- startBettingRound is called from startHand to initialize min-raise and acting order
- expand module documentation with validation rules, round-completion, and side-pot pseudocode
- fix side-pot pseudocode formatting

## Testing
- `yarn test:nextjs` *(fails: require() of ES module vite not supported)*
- `yarn next:lint` *(fails: Failed to load parser './parser.js' from eslint-config-next)*

------
https://chatgpt.com/codex/tasks/task_e_689d8f82acd08324b6bcf2797c8e182f