### PR TITLE
Anchor dealer info window below table

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -83,7 +83,10 @@ export default function PlayPage() {
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} />
       </div>
-      <div id="action-buttons" className="fixed bottom-4 right-4">
+      <div id="dealer-anchor" className="relative w-full h-px">
+        <DealerWindow />
+      </div>
+      <div id="action-buttons" className="flex justify-end p-4">
         <ActionBar
           street={stageNames[street] ?? "preflop"}
           onActivate={handleActivate}
@@ -93,7 +96,6 @@ export default function PlayPage() {
           hasHandStarted={handStarted}
         />
       </div>
-      <DealerWindow />
     </main>
   );
 }

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -1,42 +1,36 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useGameStore } from "../hooks/useGameStore";
+import useIsMobile from "../hooks/useIsMobile";
 
 export default function DealerWindow() {
   const logs = useGameStore((s) => s.logs);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [top, setTop] = useState(0);
-
-  const updatePosition = useCallback(() => {
-    const el = containerRef.current;
-    const actions = document.getElementById("action-buttons");
-    if (el && actions) {
-      const actionTop = actions.getBoundingClientRect().top;
-      setTop(Math.max(actionTop - el.offsetHeight - 8, 0));
-    }
-  }, []);
+  const isMobile = useIsMobile();
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
+    if (isMobile && !expanded) return;
     const el = containerRef.current;
     if (el) {
       el.scrollTop = el.scrollHeight;
       el.scrollLeft = el.scrollWidth;
     }
-    updatePosition();
-  }, [logs, updatePosition]);
+  }, [logs, isMobile, expanded]);
 
-  useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    return () => window.removeEventListener("resize", updatePosition);
-  }, [updatePosition]);
+  const displayLogs = isMobile && !expanded ? logs.slice(-1) : logs;
+
+  const base = "absolute left-4 top-0 w-64 bg-black/50 text-white rounded text-xs";
+  const collapsed = "h-5 p-1 overflow-hidden cursor-pointer flex items-center";
+  const open =
+    "max-h-40 p-2 overflow-y-auto flex flex-col justify-end space-y-1";
 
   return (
     <div
       ref={containerRef}
-      style={{ top }}
-      className="fixed left-4 w-64 bg-black/50 text-white rounded text-xs flex flex-row flex-nowrap space-x-2 overflow-x-auto overflow-y-hidden h-5 p-1 md:h-40 md:p-2 md:flex-col md:justify-end md:space-y-1 md:space-x-0 md:overflow-y-auto md:overflow-x-hidden"
+      className={`${base} ${isMobile && !expanded ? collapsed : open}`}
+      onClick={() => isMobile && setExpanded((e) => !e)}
     >
-      {logs.map((msg, i) => (
+      {displayLogs.map((msg, i) => (
         <div key={i} className="whitespace-nowrap">
           {msg}
         </div>

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, Fragment } from "react";
 import type { CSSProperties } from "react";
 import { useGameStore } from "../hooks/useGameStore";
+import useIsMobile from "../hooks/useIsMobile";
 import Card from "./Card";
 import { indexToCard } from "../backend";
 import PlayerSeat from "./PlayerSeat";
@@ -64,7 +65,7 @@ export default function Table({ timer }: { timer?: number | null }) {
     playerBets,
     playerAction,
   } = useGameStore();
-  const [isMobile, setIsMobile] = useState(false);
+  const isMobile = useIsMobile();
   const [tableScale, setTableScale] = useState(1);
   const [bet, setBet] = useState(bigBlind);
   const [actionTimer, setActionTimer] = useState<number | null>(null);
@@ -75,12 +76,10 @@ export default function Table({ timer }: { timer?: number | null }) {
 
   useEffect(() => {
     const handle = () => {
-      const mobile = window.innerWidth < 640;
-      setIsMobile(mobile);
-      const baseW = mobile ? 420 : 820;
-      const baseH = mobile ? 680 : 520;
-      const minTableWidth = mobile ? 360 : baseW;
-      const bottomSpace = mobile ? 100 : 0;
+      const baseW = isMobile ? 420 : 820;
+      const baseH = isMobile ? 680 : 520;
+      const minTableWidth = isMobile ? 360 : baseW;
+      const bottomSpace = isMobile ? 100 : 0;
       const minScale = minTableWidth / baseW;
       const scale = Math.min(
         Math.max(window.innerWidth / baseW, minScale),
@@ -92,7 +91,7 @@ export default function Table({ timer }: { timer?: number | null }) {
     handle();
     window.addEventListener("resize", handle);
     return () => window.removeEventListener("resize", handle);
-  }, []);
+  }, [isMobile]);
 
   const layout = useMemo(() => buildLayout(isMobile), [isMobile]);
   const localIdx = useMemo(() => {

--- a/packages/nextjs/hooks/useIsMobile.ts
+++ b/packages/nextjs/hooks/useIsMobile.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handle = () => setIsMobile(window.innerWidth < 640);
+    handle();
+    window.addEventListener("resize", handle);
+    return () => window.removeEventListener("resize", handle);
+  }, []);
+
+  return isMobile;
+}
+
+export default useIsMobile;


### PR DESCRIPTION
## Summary
- Share mobile detection logic with new `useIsMobile` hook
- Collapse dealer log to a single line on phones and expand on tap
- Anchor dealer log window to a 1px divider between table and action buttons

## Testing
- ⚠️ `yarn next:lint` *(failed: eslint-config-next missing dependency)*
- ⚠️ `yarn test:nextjs` *(failed: require() of ES Module vite from vitest)*

------
https://chatgpt.com/codex/tasks/task_e_689d87651da083248726327acfd9a74d