### PR TITLE
feat: rotate and cleanup after payouts

### DIFF
--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -62,15 +62,14 @@ This document describes the server-side `TableState` lifecycle for a single no-l
 ### 9. **PAYOUT**
 
 - **Entry**: Winners resolved.
-- **Actions**: Chips are distributed, rake is applied, remainder chips from split pots are awarded clockwise from the button and pots cleared. Players reduced to zero chips are marked **SITTING_OUT** or removed when re-buy is disallowed.
- - **Actions**: Chips are distributed, rake is applied, remainder chips from split pots are awarded clockwise from the button and pots cleared. Players reduced to zero chips are marked **SITTING_OUT** or flagged **LEAVING** when re-buy is disallowed.
+- **Actions**: Chips are distributed, rake is applied, remainder chips from split pots are awarded clockwise from the button and pots cleared. Players reduced to zero chips are marked **SITTING_OUT** or flagged **LEAVING** when re-buy is disallowed.
 - **Exit**: Stacks updated and pots emptied.
 - **Edge Cases**: Transfer failures pause the table until resolved.
 
 ### 10. **ROTATE**
 
 - **Entry**: Payout complete.
-- **Actions**: Dealer button moves to the next active seat clockwise. Returning players who missed blinds must either post the
+- **Actions**: Remove or flag players marked **LEAVING**, then move the dealer button to the next active seat clockwise. Returning players who missed blinds must either post the
   big blind (and small blind if required) immediately (`deadBlindRule = POST`) or wait for the big blind to reach them
   (`deadBlindRule = WAIT`). If the small-blind seat is empty, blinds roll forward to the next available active seats.
 - **Exit**: Rotation finished.
@@ -78,8 +77,8 @@ This document describes the server-side `TableState` lifecycle for a single no-l
 ### 11. **CLEANUP**
 
 - **Entry**: Rotation complete.
-- **Actions**: Board, pots and per-hand metadata are reset. Players marked **LEAVING** are removed.
-- **Exit**: If at least two active players can post the blinds, the table waits `interRoundDelayMs` then returns to **BLINDS**. Otherwise it falls back to **WAITING**.
+- **Actions**: Clear per-hand metadata such as board cards, pots and betting state while leaving stacks unchanged.
+- **Exit**: If at least two active players can post the blinds, the table waits `interRoundDelayMs` then returns to **BLINDS**; otherwise it falls back to **WAITING**.
 
 ### **PAUSED** _(optional)_
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -10,7 +10,7 @@ betting rounds progress, see [`dealing-and-betting.md`](./dealing-and-betting.md
 
 | Module                   | Responsibility                                                                                                                                                                                                                         |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TableManager**         | Orchestrates the hand lifecycle and table state machine, moves the dealer button after payouts and enforces the minimum number of active players.                                                                                      |
+| **TableManager**         | Orchestrates the hand lifecycle and table state machine, rotates through **ROTATE** and **CLEANUP** after payouts while enforcing the minimum number of active players.                                                                |
 | **SeatingManager**       | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions. Voluntary sit-outs take effect after the current hand. At hand end, broke players are marked `SITTING_OUT` if re‑buy is allowed or `LEAVING` when it is not. |
 | **BlindManager**         | Assigns blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and applies configurable dead‑blind rules for returning players.                                                                      |
 | **Dealer**               | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server.                                                                                                             |
@@ -31,7 +31,7 @@ Typical hand lifecycle:
 2. `BettingEngine` prompts the acting player. After each action it updates commitments and asks `PotManager` to rebuild pots on all‑ins.
 3. When a round completes, `BettingEngine` signals the `Dealer` to deal the next street or proceeds to showdown.
 4. At showdown, `HandEvaluator` ranks hands and `PotManager` awards pots, applying rake if configured.
-5. `TableManager` rotates the button and resets per‑hand state for the next hand.
+5. `TableManager` advances through **ROTATE** and **CLEANUP**, moving the button, clearing per-hand data and after `interRoundDelayMs` either restarting in **BLINDS** or waiting for more players.
 
 This separation keeps rendering, state management and game rules isolated and mirrors the architecture described in the design guidelines.
 


### PR DESCRIPTION
## Summary
- step through ROTATE and CLEANUP after payouts before starting a new hand
- document table reset and inter-round behavior

## Testing
- `npx prettier --check packages/nextjs/backend/handReset.ts docs/game-states.md docs/modules.md`
- `NODE_OPTIONS=--experimental-vm-modules yarn test:nextjs` *(fails: require() of ES Module)*
- `yarn test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_689d9aebe9708324a388c908bc45fb5a