### PR TITLE
feat: add table manager

### DIFF
--- a/packages/nextjs/backend/tableManager.ts
+++ b/packages/nextjs/backend/tableManager.ts
@@ -1,0 +1,85 @@
+import {
+  Table,
+  PlayerAction,
+  Round,
+  TableState,
+} from './types';
+import { TableStateMachine } from './tableStateMachine';
+import { startHand as startHandLifecycle, endHand } from './handLifecycle';
+import {
+  applyAction,
+  isRoundComplete,
+  startBettingRound,
+} from './bettingEngine';
+import { dealBoard } from './dealer';
+import { countActivePlayers } from './tableUtils';
+
+/**
+ * TableManager orchestrates the hand lifecycle for a single table. It uses the
+ * lower level modules (dealer, betting engine, etc.) and advances the
+ * {@link TableStateMachine} according to PokerTH's workflow.
+ */
+export class TableManager {
+  private fsm: TableStateMachine;
+  constructor(public table: Table) {
+    this.fsm = new TableStateMachine();
+    this.fsm.state = table.state;
+  }
+
+  /** Attempt to begin a new hand */
+  startHand(): boolean {
+    this.fsm.dispatch({
+      type: 'START_HAND',
+      activeSeats: countActivePlayers(this.table),
+    });
+    if (this.fsm.state !== TableState.BLINDS) return false;
+    const ok = startHandLifecycle(this.table);
+    if (ok) {
+      this.fsm.dispatch({ type: 'BLINDS_POSTED' });
+      this.fsm.dispatch({ type: 'DEALING_COMPLETE' });
+    }
+    return ok;
+  }
+
+  /** Apply an action for the given seat and progress the hand if needed. */
+  async handleAction(
+    seatIndex: number,
+    action: { type: PlayerAction; amount?: number },
+  ) {
+    applyAction(this.table, seatIndex, action);
+    if (!isRoundComplete(this.table)) return;
+
+    const remaining = countActivePlayers(this.table);
+    this.fsm.dispatch({ type: 'BETTING_COMPLETE', remainingPlayers: remaining });
+
+    switch (this.fsm.state) {
+      case TableState.FLOP:
+        dealBoard(this.table, Round.FLOP);
+        this.table.currentRound = Round.FLOP;
+        startBettingRound(this.table, Round.FLOP);
+        break;
+      case TableState.TURN:
+        dealBoard(this.table, Round.TURN);
+        this.table.currentRound = Round.TURN;
+        startBettingRound(this.table, Round.TURN);
+        break;
+      case TableState.RIVER:
+        dealBoard(this.table, Round.RIVER);
+        this.table.currentRound = Round.RIVER;
+        startBettingRound(this.table, Round.RIVER);
+        break;
+      case TableState.SHOWDOWN:
+      case TableState.PAYOUT:
+        await endHand(this.table);
+        this.fsm.dispatch({ type: 'PAYOUT_COMPLETE' });
+        this.fsm.dispatch({ type: 'ROTATION_COMPLETE' });
+        this.fsm.dispatch({
+          type: 'CLEANUP_COMPLETE',
+          activeSeats: countActivePlayers(this.table),
+        });
+        break;
+    }
+  }
+}
+
+export default TableManager;

--- a/packages/nextjs/backend/tests/tableManager.test.ts
+++ b/packages/nextjs/backend/tests/tableManager.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import TableManager from '../tableManager';
+import {
+  Table,
+  Player,
+  PlayerState,
+  PlayerAction,
+  TableState,
+  Round,
+} from '../types';
+
+const createPlayer = (
+  id: string,
+  seatIndex: number,
+  stack: number,
+): Player => ({
+  id,
+  seatIndex,
+  stack,
+  state: PlayerState.ACTIVE,
+  hasButton: false,
+  autoPostBlinds: true,
+  timebankMs: 0,
+  betThisRound: 0,
+  totalCommitted: 0,
+  holeCards: [],
+  lastAction: PlayerAction.NONE,
+  missedSmallBlind: false,
+  missedBigBlind: false,
+});
+
+const createTable = (seats: (Player | null)[]): Table => ({
+  seats,
+  buttonIndex: 0,
+  smallBlindIndex: -1,
+  bigBlindIndex: -1,
+  smallBlindAmount: 5,
+  bigBlindAmount: 10,
+  minBuyIn: 0,
+  maxBuyIn: 0,
+  state: TableState.BLINDS,
+  deck: [],
+  board: [],
+  pots: [],
+  currentRound: Round.PREFLOP,
+  actingIndex: null,
+  betToCall: 0,
+  minRaise: 0,
+  lastFullRaise: null,
+  actedSinceLastRaise: new Set(),
+  actionTimer: 0,
+  interRoundDelayMs: 0,
+  dealAnimationDelayMs: 0,
+});
+
+describe('TableManager', () => {
+  it('completes a hand when the first player folds preflop', async () => {
+    const table = createTable([
+      createPlayer('a', 0, 100),
+      createPlayer('b', 1, 100),
+    ]);
+    const mgr = new TableManager(table);
+    const started = mgr.startHand();
+    expect(started).toBe(true);
+    expect(table.state).toBe(TableState.PRE_FLOP);
+    const actor = table.actingIndex!;
+    await mgr.handleAction(actor, { type: PlayerAction.FOLD });
+    expect(table.state).toBe(TableState.BLINDS);
+    expect(table.seats[1]?.stack).toBe(105);
+  });
+});


### PR DESCRIPTION
## Summary
- orchestrate hand lifecycle via new TableManager coordinating existing modules
- add test ensuring a preflop fold finishes the hand and awards blinds

## Testing
- `yarn format:check` (warn)
- `yarn next:lint` (fail: eslint-config-next missing dependency)
- `yarn next:check-types` (fail: TypeScript config errors)
- `yarn test:nextjs` (fail: vitest config requires ESM)


------
https://chatgpt.com/codex/tasks/task_e_689e26e64ce08324996561e96435ee72