### PR TITLE
Fix DealerWindow positioning

### DIFF
--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -8,7 +8,6 @@ export default function DealerWindow() {
   const isMobile = useIsMobile();
   const [expanded, setExpanded] = useState(false);
 
-
   useEffect(() => {
     if (isMobile && !expanded) return;
     const el = containerRef.current;
@@ -20,7 +19,8 @@ export default function DealerWindow() {
 
   const displayLogs = isMobile && !expanded ? logs.slice(-1) : logs;
 
-  const base = "absolute left-4 top-0 w-64 bg-black/50 text-white rounded text-xs";
+  const base =
+    "absolute left-4 bottom-0 w-64 bg-black/50 text-white rounded text-xs";
 
   const collapsed = "h-5 p-1 overflow-hidden cursor-pointer flex items-center";
   const open =


### PR DESCRIPTION
## Summary
- keep dealer info view within window by anchoring to bottom

## Testing
- `yarn next:lint` *(fails: Failed to load parser './parser.js' declared in '.eslintrc.json » eslint-config-next')*
- `yarn next:check-types` *(fails: Cannot find module '@starknet-react/core' or its corresponding type declarations and many others)*
- `yarn test:nextjs` *(fails: Error: require() of ES Module vite from vitest config is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689f127233c48324ad05507b75840431