### PR TITLE
fix: stick bottom overlays to viewport

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -83,10 +83,11 @@ export default function PlayPage() {
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} />
       </div>
-      <div id="dealer-anchor" className="relative w-full h-px">
-        <DealerWindow />
-      </div>
-      <div id="action-buttons" className="flex justify-end p-4">
+      <DealerWindow />
+      <div
+        id="action-buttons"
+        className="fixed bottom-0 right-0 flex justify-end p-4 z-10"
+      >
         <ActionBar
           street={stageNames[street] ?? "preflop"}
           onActivate={handleActivate}

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -20,7 +20,7 @@ export default function DealerWindow() {
   const displayLogs = isMobile && !expanded ? logs.slice(-1) : logs;
 
   const base =
-    "absolute left-4 bottom-0 w-64 bg-black/50 text-white rounded text-xs";
+    "fixed left-4 bottom-0 w-64 bg-black/50 text-white rounded text-xs z-10";
 
   const collapsed = "h-5 p-1 overflow-hidden cursor-pointer flex items-center";
   const open =


### PR DESCRIPTION
## Summary
- Keep dealer log window fixed to bottom-left
- Fix action buttons to bottom-right so controls stay in view

## Testing
- `yarn next:lint` *(fails: eslint-config-next tried to access next)*
- `yarn next:check-types` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a57dda0ff88324986e05d09655a9b8