### PR TITLE
docs: describe turn order, project structure, and sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Getting Started
 
 This repository uses **Node 20** and **Yarn 3** workspaces.
+For an overview of the directory layout see [docs/project-structure.md](docs/project-structure.md).
 
 ```bash
 corepack enable
@@ -46,3 +47,4 @@ yarn vercel
 Environment variables such as `NEXT_PUBLIC_PROVIDER_URL` configure Starknet RPC endpoints. The app falls back to `NEXT_PUBLIC_DEVNET_PROVIDER_URL` when the primary endpoint is unavailable.
 
 For details on the WebSocket protocol between clients and the poker server, see [docs/networking-contract.md](docs/networking-contract.md).
+Session creation and unique user identifiers are covered in [docs/multi-player-server.md](docs/multi-player-server.md).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,3 +10,6 @@ The following items from the implementation checklist remain unfinished:
   - Side pots with three or more all-ins.
   - Dead-blind returns.
 
+- Enforce turn order with a dedicated manager that advances `actingIndex` and rejects out-of-turn commands.
+- Maintain seats as persistent structures to prevent index reshuffling when players join, leave, or sit out.
+- Implement session management that assigns a Starknet-style public address per connection and enforces one user per session.

--- a/docs/multi-player-server.md
+++ b/docs/multi-player-server.md
@@ -1,0 +1,21 @@
+# Multiplayer Server & Session Management
+
+This document outlines how the poker server tracks connected players and guarantees unique identities.
+
+## Session Lifecycle
+
+- When a client connects, the server creates a new session object scoped to that network connection.
+- Each session is associated with **exactly one user**. Additional connections must negotiate a separate session.
+- Sessions terminate when the connection closes or when the server explicitly revokes them.
+
+## User Identifier
+
+- Upon session creation the server assigns a `userId` representing the player.
+- The identifier is formatted like a Starknet public address: a 0x-prefixed hexadecimal string.
+- Commands and events carry this `userId` so that state changes can be attributed to a single wallet-like address.
+
+## Guarantees
+
+- Only one user may exist per session; attempts to reuse or share a session are rejected.
+- A fresh `userId` is generated for each new session, preventing collisions across reconnects.
+- Future extensions may sign messages with a Starknet private key to prove control over the `userId`.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,33 @@
+# Project Structure
+
+This monorepo uses **Yarn 3** workspaces to separate the web client and smart contract code.
+
+## Root
+
+- `package.json` – workspace configuration and shared scripts.
+- `docs/` – design documents such as [turn-order-and-seating](./turn-order-and-seating.md) and this overview.
+- `packages/` – all runnable source code lives inside these packages.
+
+## `packages/nextjs`
+
+Next.js application that serves the PokerNFTs UI and API routes.
+
+Directory highlights:
+
+- `app/` – React components and routing.
+- `lib/` – shared utilities used by server and client modules.
+- `tests/` – Vitest unit tests.
+
+## `packages/snfoundry`
+
+Cairo smart contracts and scripts for Starknet Foundry.
+
+Directory highlights:
+
+- `src/` – contract sources.
+- `lib/` – reusable Cairo libraries.
+- `tests/` – `snforge` test suites.
+
+## Extending the Layout
+
+Add new top-level folders within the appropriate package and update this document when the project grows.

--- a/docs/turn-order-and-seating.md
+++ b/docs/turn-order-and-seating.md
@@ -1,0 +1,43 @@
+# Turn Order & Seating Structures
+
+This document outlines data structures typically used in poker software to ensure players act in the correct sequence and that seats remain consistent throughout play.
+
+## Turn Management
+
+- Maintain a circular array of seat objects representing each position at the table.
+- Track the `actingIndex` pointing to the seat whose turn it is.
+- A helper such as `nextActiveSeat(startIndex)` advances clockwise, skipping seats that are `null`, `SITTING_OUT`, `FOLDED`, or `ALL_IN`.
+- Actions are only accepted from the player at `actingIndex`. Invalid or out-of-turn actions are rejected.
+- After a valid action, update `actingIndex` to the next active seat and determine if the betting round is complete.
+
+## Seat Structure
+
+- Each seat holds either a `Player` object or `null` when empty.
+- Seat objects persist across hands so that identifiers, stack sizes, and configuration flags remain stable.
+- Transitions such as a player leaving or sitting out update the seat state rather than reshuffling the array, preserving turn order.
+- Utility functions should safely insert or remove players while maintaining the circular structure.
+
+## Architecture
+
+Most poker engines organize state into three core models:
+
+1. **Player** – chips, hand cards, and current status such as folded or all-in.
+2. **Seat** – table position referencing a `Player` or `null` when empty.
+3. **Table** – collection of seats plus metadata like blind sizes, button index, pot, and deck state.
+
+The table acts as the single source of truth and exposes an API to specialized modules:
+
+- **TurnManager** – tracks `actingIndex`, validates whose turn it is, and advances to the next active seat.
+- **BettingEngine** – verifies bet sizes, builds pots, and determines round completion.
+- **BlindManager** – posts blinds/antes and handles dead-blind returns.
+- **Dealer** – shuffles, deals cards, and progresses through hand stages.
+
+Each module reads from and mutates the table state through clear interfaces so that actions can be audited and replayed deterministically. A typical hand flows through these steps:
+
+1. `BlindManager` posts blinds and updates stacks.
+2. `Dealer` deals cards and initializes `actingIndex`.
+3. The game loop calls `TurnManager` to request the next action.
+4. Accepted actions are processed by `BettingEngine`, which may update pots and signal round completion.
+5. When a betting round ends, `Dealer` advances the stage or awards the pot.
+
+By centralizing state and isolating responsibilities, the architecture maintains seat integrity and enforces turn order even as players join, leave, or sit out.


### PR DESCRIPTION
## Summary
- document turn order and seating data structures for poker engine
- note tasks for enforcing turn order, persistent seats, and session-based identities
- expand architecture overview with modules and game flow
- outline monorepo project structure and link from README
- describe multiplayer server sessions that issue Starknet-style user IDs

## Testing
- `yarn install` *(fails: fetching dependencies from registry)*
- `yarn format:check` *(fails: project not installed)*
- `yarn next:lint` *(fails: project not installed)*
- `yarn next:check-types` *(fails: project not installed)*
- `yarn test:nextjs` *(fails: project not installed)*
- `yarn test` *(fails: project not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6683a38bc8324a88f601401198016