### PR TITLE
Add lobby page and session persistence

### DIFF
--- a/packages/nextjs/app/lobby/page.test.tsx
+++ b/packages/nextjs/app/lobby/page.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import LobbyPage from './page';
+import { expect, test } from 'vitest';
+
+// basic render test for lobby
+
+test('renders lobby with table links', () => {
+  render(<LobbyPage />);
+  expect(screen.getByText('Lobby')).toBeInTheDocument();
+  const links = screen.getAllByRole('link', { name: 'Join' });
+  expect(links[0]).toHaveAttribute('href', '/play?table=demo');
+});
+

--- a/packages/nextjs/app/lobby/page.tsx
+++ b/packages/nextjs/app/lobby/page.tsx
@@ -1,4 +1,39 @@
-export default function LobbyPage() {
-  // TODO: implement lobby selection view (Action Plan 1.1)
-  return <div>Lobby TODO</div>;
+'use client';
+
+import Link from 'next/link';
+
+interface TableInfo {
+  id: string;
+  name: string;
+  stakes: string;
 }
+
+const TABLES: TableInfo[] = [
+  { id: 'demo', name: 'Demo Table', stakes: 'Free' },
+  { id: 'high', name: 'High Stakes', stakes: '50/100' },
+];
+
+export default function LobbyPage() {
+  return (
+    <main className="p-6 text-white">
+      <h1 className="text-2xl mb-4">Lobby</h1>
+      <ul className="space-y-3">
+        {TABLES.map((t) => (
+          <li key={t.id} className="flex items-center justify-between bg-black/40 rounded p-4">
+            <div>
+              <div className="font-semibold">{t.name}</div>
+              <div className="text-sm text-gray-300">Stakes: {t.stakes}</div>
+            </div>
+            <Link
+              href={`/play?table=${t.id}`}
+              className="px-3 py-1 rounded bg-red-600 hover:bg-red-700 text-white"
+            >
+              Join
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -21,6 +21,8 @@ export default function PlayPage() {
     stageNames,
     handStarted,
     handleActivate,
+    socket,
+    sessionId,
   } = usePlayViewModel();
 
   return (
@@ -41,7 +43,7 @@ export default function PlayPage() {
         </div>
       </header>
       <div className="flex-1 flex items-center justify-center">
-        <Table timer={timer} />
+        <Table timer={timer} socket={socket} />
       </div>
       <DealerWindow />
       <div

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -10,7 +10,13 @@ import type { UiPlayer, Card as TCard } from "../backend";
 
 /* ─────────────────────────────────────────────────────── */
 
-export default function Table({ timer }: { timer?: number | null }) {
+export default function Table({
+  timer,
+  socket,
+}: {
+  timer?: number | null;
+  socket?: WebSocket | null;
+}) {
   const {
     players,
     playerHands,
@@ -35,7 +41,7 @@ export default function Table({ timer }: { timer?: number | null }) {
     displayTimer,
     actionDisabled,
     handleActionClick,
-  } = useTableViewModel(timer);
+  } = useTableViewModel(timer, socket);
 
   const holeCardSize = "sm";
 

--- a/packages/nextjs/hooks/usePlayViewModel.ts
+++ b/packages/nextjs/hooks/usePlayViewModel.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useGameStore } from "./useGameStore";
 
-// TODO: persist session tokens and auto-reconnect (Action Plan 1.3)
-
+/**
+ * Persist a session token from the backend websocket and attempt to reattach on reload.
+ */
 const stageNames = ["preflop", "flop", "turn", "river", "showdown"] as const;
 
 export function usePlayViewModel() {
@@ -17,9 +18,41 @@ export function usePlayViewModel() {
     startBlindTimer,
   } = useGameStore();
   const [timer, setTimer] = useState<number | null>(null);
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
 
   const handStarted = playerHands.some((h) => h !== null);
   const activePlayers = players.filter(Boolean).length;
+
+  // establish websocket connection and persist session token
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("sessionId") : null;
+    const ws = new WebSocket("ws://localhost:8080");
+    ws.onopen = () => {
+      if (stored) {
+        ws.send(
+          JSON.stringify({
+            cmdId: crypto.randomUUID(),
+            type: "ATTACH",
+            sessionId: stored,
+          }),
+        );
+      }
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data as string);
+        if (msg.type === "SESSION" && msg.userId) {
+          setSessionId(msg.userId);
+          localStorage.setItem("sessionId", msg.userId);
+        }
+      } catch {
+        /* ignore malformed */
+      }
+    };
+    setSocket(ws);
+    return () => ws.close();
+  }, []);
 
   useEffect(() => {
     const originalBody = document.body.style.overflow;
@@ -67,5 +100,7 @@ export function usePlayViewModel() {
     stageNames,
     handStarted,
     handleActivate,
+    socket,
+    sessionId,
   };
 }

--- a/packages/nextjs/hooks/useTableViewModel.ts
+++ b/packages/nextjs/hooks/useTableViewModel.ts
@@ -45,7 +45,7 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
   });
 };
 
-export function useTableViewModel(timer?: number | null) {
+export function useTableViewModel(timer?: number | null, socket?: WebSocket | null) {
   const {
     players,
     playerHands,
@@ -149,7 +149,17 @@ export function useTableViewModel(timer?: number | null) {
   const displayTimer = actionTimer ?? timer ?? 0;
 
   const handleActionClick = (action: string) => {
-    // TODO: emit PlayerAction messages via networking contract (Action Plan 1.2)
+    // emit PlayerAction messages via networking contract when socket is available
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      const payload: any = {
+        cmdId: crypto.randomUUID(),
+        type: "ACTION",
+        action: action.toUpperCase(),
+        amount: action === "Bet" || action === "Raise" ? bet : undefined,
+        tableId: "demo",
+      };
+      socket.send(JSON.stringify(payload));
+    }
     switch (action) {
       case "Fold":
         playerAction({ type: "fold" });

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -2,6 +2,7 @@
   "name": "@ss-2/nextjs",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "next build",
     "dev": "next dev -H 0.0.0.0 -p 3005",

--- a/packages/nextjs/server/index.ts
+++ b/packages/nextjs/server/index.ts
@@ -75,6 +75,31 @@ wss.on("connection", (ws) => {
       set.add(msg.cmdId);
 
       switch (msg.type) {
+        case "ATTACH": {
+          const attached = sessions.attach(ws, msg.sessionId);
+          if (attached) {
+            session.id = attached.id;
+            session.roomId = attached.roomId;
+            ws.send(
+              JSON.stringify({
+                tableId: attached.roomId ?? "",
+                type: "SESSION",
+                userId: attached.id,
+              } satisfies ServerEvent),
+            );
+            if (attached.roomId) {
+              const room = getRoom(attached.roomId);
+              ws.send(
+                JSON.stringify({
+                  tableId: room.id,
+                  type: "TABLE_SNAPSHOT",
+                  table: room,
+                } satisfies ServerEvent),
+              );
+            }
+          }
+          break;
+        }
         case "SIT": {
           const room = getRoom(msg.tableId);
           const nickname = shortAddress(session.id);


### PR DESCRIPTION
## Summary
- implement lobby selection page
- persist session tokens and emit player actions over WebSocket
- add basic lobby render test

## Testing
- `yarn test:nextjs` *(fails: backend tests and missing build)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c454ce7483249ca1b20f46b82973