### PR TITLE
Add JSON interfaces and tests

### DIFF
--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -2,6 +2,12 @@ import { Table, Player, PlayerState, PlayerAction, Round } from "./types";
 import { rebuildPots, resetForNextRound } from "./potManager";
 import { isHeadsUp } from "./tableUtils";
 import { AuditLogger } from "./auditLogger";
+import {
+  BettingActionRequest,
+  BettingActionResponse,
+  tableFromJson,
+  tableToJson,
+} from "./jsonFormats";
 
 /** Initialize betting round and determine first to act */
 export function startBettingRound(table: Table, round: Round) {
@@ -169,6 +175,14 @@ export function applyAction(
 
   // advance turn
   table.actingIndex = nextToAct(table, seatIndex);
+}
+
+export function applyActionFromJson(
+  req: BettingActionRequest,
+): BettingActionResponse {
+  const table = tableFromJson(req.table);
+  applyAction(table, req.seatIndex, req.action);
+  return { actingIndex: table.actingIndex, table: tableToJson(table) };
 }
 
 function nextToAct(table: Table, from: number): number | null {

--- a/packages/nextjs/backend/handEvaluator.ts
+++ b/packages/nextjs/backend/handEvaluator.ts
@@ -1,5 +1,6 @@
 import { RANKS } from './constants';
 import type { Card } from './types';
+import type { HandEvaluatorRequest, HandEvaluatorResponse } from './jsonFormats';
 
 export interface RankedHand {
   rankValue: number; // lower = better
@@ -164,4 +165,10 @@ export function compareHands(a: RankedHand, b: RankedHand): number {
     if (diff !== 0) return diff;
   }
   return 0;
+}
+
+export function rankHandFromJson(
+  input: HandEvaluatorRequest,
+): HandEvaluatorResponse {
+  return rankHand(input.cards);
 }

--- a/packages/nextjs/backend/jsonFormats.ts
+++ b/packages/nextjs/backend/jsonFormats.ts
@@ -1,0 +1,33 @@
+import type { Card, PlayerAction, Table } from './types';
+
+export interface HandEvaluatorRequest {
+  cards: Card[];
+}
+
+export interface HandEvaluatorResponse {
+  rankValue: number;
+  bestCards: Card[];
+}
+
+export interface JsonTable extends Omit<Table, 'actedSinceLastRaise'> {
+  actedSinceLastRaise: number[];
+}
+
+export interface BettingActionRequest {
+  table: JsonTable;
+  seatIndex: number;
+  action: { type: PlayerAction; amount?: number };
+}
+
+export interface BettingActionResponse {
+  actingIndex: number | null;
+  table: JsonTable;
+}
+
+export function tableFromJson(json: JsonTable): Table {
+  return { ...json, actedSinceLastRaise: new Set(json.actedSinceLastRaise) };
+}
+
+export function tableToJson(table: Table): JsonTable {
+  return { ...table, actedSinceLastRaise: Array.from(table.actedSinceLastRaise) };
+}

--- a/packages/nextjs/backend/tests/bettingEngineJson.test.ts
+++ b/packages/nextjs/backend/tests/bettingEngineJson.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { applyActionFromJson } from '../bettingEngine';
+import { isRoundComplete } from '../bettingEngine';
+import { tableFromJson } from '../jsonFormats';
+import type { BettingActionRequest } from '../jsonFormats';
+
+describe('BettingEngine JSON interface', () => {
+  it('processes actions from JSON state', () => {
+    const file = path.join(__dirname, 'data', 'bettingEngine.json');
+    const raw = readFileSync(file, 'utf8');
+    const data = JSON.parse(raw) as {
+      table: BettingActionRequest['table'];
+      actions: { seatIndex: number; action: { type: any; amount?: number } }[];
+      expected: { actingIndex: number | null };
+    };
+
+    let jsonTable = data.table;
+    for (const step of data.actions) {
+      const res = applyActionFromJson({
+        table: jsonTable,
+        seatIndex: step.seatIndex,
+        action: step.action,
+      });
+      jsonTable = res.table;
+    }
+    const finalTable = tableFromJson(jsonTable);
+    expect(finalTable.actingIndex).toBe(data.expected.actingIndex);
+    expect(isRoundComplete(finalTable)).toBe(true);
+  });
+});

--- a/packages/nextjs/backend/tests/data/bettingEngine.json
+++ b/packages/nextjs/backend/tests/data/bettingEngine.json
@@ -1,0 +1,37 @@
+{
+  "table": {
+    "seats": [
+      {"id":"a","seatIndex":0,"stack":100,"state":"ACTIVE","hasButton":false,"autoPostBlinds":true,"timebankMs":0,"betThisRound":0,"totalCommitted":0,"holeCards":[],"lastAction":"NONE"},
+      {"id":"b","seatIndex":1,"stack":95,"state":"ACTIVE","hasButton":false,"autoPostBlinds":true,"timebankMs":0,"betThisRound":5,"totalCommitted":5,"holeCards":[],"lastAction":"NONE"},
+      {"id":"c","seatIndex":2,"stack":90,"state":"ACTIVE","hasButton":false,"autoPostBlinds":true,"timebankMs":0,"betThisRound":10,"totalCommitted":10,"holeCards":[],"lastAction":"NONE"}
+    ],
+    "buttonIndex":0,
+    "smallBlindIndex":1,
+    "bigBlindIndex":2,
+    "smallBlindAmount":5,
+    "bigBlindAmount":10,
+    "minBuyIn":0,
+    "maxBuyIn":0,
+    "state":"PRE_FLOP",
+    "deck": [],
+    "board": [],
+    "pots": [],
+    "currentRound":"PREFLOP",
+    "actingIndex":0,
+    "betToCall":10,
+    "minRaise":10,
+    "lastFullRaise":null,
+    "actedSinceLastRaise":[],
+    "actionTimer":0,
+    "interRoundDelayMs":0,
+    "dealAnimationDelayMs":0
+  },
+  "actions": [
+    {"seatIndex":0,"action":{"type":"RAISE","amount":20}},
+    {"seatIndex":1,"action":{"type":"FOLD"}},
+    {"seatIndex":2,"action":{"type":"CALL"}}
+  ],
+  "expected": {
+    "actingIndex": null
+  }
+}

--- a/packages/nextjs/backend/tests/data/handEvaluator.json
+++ b/packages/nextjs/backend/tests/data/handEvaluator.json
@@ -1,0 +1,21 @@
+{
+  "cards": [
+    {"rank": "A", "suit": "\u2660"},
+    {"rank": "K", "suit": "\u2660"},
+    {"rank": "Q", "suit": "\u2660"},
+    {"rank": "J", "suit": "\u2660"},
+    {"rank": "T", "suit": "\u2660"},
+    {"rank": "9", "suit": "\u2663"},
+    {"rank": "2", "suit": "\u2665"}
+  ],
+  "expected": {
+    "rankValue": 1,
+    "bestCards": [
+      {"rank": "A", "suit": "\u2660"},
+      {"rank": "K", "suit": "\u2660"},
+      {"rank": "Q", "suit": "\u2660"},
+      {"rank": "J", "suit": "\u2660"},
+      {"rank": "T", "suit": "\u2660"}
+    ]
+  }
+}

--- a/packages/nextjs/backend/tests/handEvaluatorJson.test.ts
+++ b/packages/nextjs/backend/tests/handEvaluatorJson.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { rankHandFromJson } from '../handEvaluator';
+import type { HandEvaluatorRequest, HandEvaluatorResponse } from '../jsonFormats';
+
+describe('HandEvaluator JSON interface', () => {
+  it('evaluates hand from JSON', () => {
+    const file = path.join(__dirname, 'data', 'handEvaluator.json');
+    const raw = readFileSync(file, 'utf8');
+    const data = JSON.parse(raw) as HandEvaluatorRequest & { expected: HandEvaluatorResponse };
+    const result = rankHandFromJson({ cards: data.cards });
+    expect(result.rankValue).toBe(data.expected.rankValue);
+    expect(result.bestCards).toEqual(data.expected.bestCards);
+  });
+});


### PR DESCRIPTION
## Summary
- define shared JSON request/response formats and table converters
- add JSON wrapper utilities for HandEvaluator and BettingEngine
- introduce JSON-driven tests for hand evaluation and betting actions

## Testing
- `yarn test:nextjs` *(fails: missing dist and multiple assertion failures)*
- `yarn workspace @ss-2/nextjs vitest run backend/tests/handEvaluatorJson.test.ts backend/tests/bettingEngineJson.test.ts`
- `yarn workspace @ss-2/nextjs format:check` *(fails: formatting issues in many files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c6d8399483248e128563ee8d6a81