### PR TITLE
Clear folded hands and test game engine flow

### DIFF
--- a/packages/nextjs/backend/room.ts
+++ b/packages/nextjs/backend/room.ts
@@ -49,9 +49,7 @@ export function startHand(room: GameRoom) {
   room.deck = dealDeck();
   room.communityCards = [];
   room.pot = 0;
-  if (winners.length === 1) {
-    room.players = room.players.filter((p) => p.chips > 0);
-  }
+  room.players = room.players.filter((p) => p.chips > 0);
   if (room.stage === "waiting") {
     room.dealerIndex = randomInt(room.players.length);
   } else {
@@ -98,6 +96,7 @@ export function handleAction(
   switch (action.type) {
     case "fold":
       player.hasFolded = true;
+      player.hand = [];
       break;
     case "call": {
       const toCall = currentMax - player.currentBet;

--- a/packages/nextjs/backend/tests/gameEngine.test.ts
+++ b/packages/nextjs/backend/tests/gameEngine.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { GameEngine } from '../gameEngine';
+
+describe('GameEngine', () => {
+  it('advances through stages and resets for a new hand', () => {
+    const engine = new GameEngine('t1', 10);
+    engine.addPlayer({ id: 'a', nickname: 'A', seat: 0, chips: 100 });
+    engine.addPlayer({ id: 'b', nickname: 'B', seat: 1, chips: 100 });
+
+    engine.startHand();
+    expect(engine.getState().stage).toBe('preflop');
+
+    engine.progressStage();
+    expect(engine.getState().stage).toBe('flop');
+    engine.progressStage();
+    expect(engine.getState().stage).toBe('turn');
+    engine.progressStage();
+    expect(engine.getState().stage).toBe('river');
+    engine.progressStage();
+    expect(engine.getState().stage).toBe('showdown');
+
+    const winners = engine.determineWinners();
+    engine.payout(winners);
+
+    engine.startHand();
+    expect(engine.getState().stage).toBe('preflop');
+  });
+
+  it('clears player hand on fold', () => {
+    const engine = new GameEngine('t2', 10);
+    engine.addPlayer({ id: 'a', nickname: 'A', seat: 0, chips: 100 });
+    engine.addPlayer({ id: 'b', nickname: 'B', seat: 1, chips: 100 });
+
+    engine.startHand();
+    const room = engine.getState();
+    const foldingId = room.players[room.currentTurnIndex].id;
+    expect(room.players.find(p => p.id === foldingId)?.hand.length).toBe(2);
+    engine.handleAction(foldingId, { type: 'fold' });
+    expect(engine.getState().players.find(p => p.id === foldingId)?.hand.length).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Remove undefined winners usage and drop players with zero chips when a hand starts
- Clear a player's hole cards when they fold
- Add integration tests covering game engine stage progression and folding behavior

## Testing
- `yarn test:nextjs` *(fails: blindsTable, dealerBetting, room)*

------
https://chatgpt.com/codex/tasks/task_e_68a723e3bddc8324a37b919cc04bccab