### PR TITLE
Fix blind assignment and remove busted players

### DIFF
--- a/packages/nextjs/backend/blindManager.ts
+++ b/packages/nextjs/backend/blindManager.ts
@@ -87,6 +87,9 @@ export function assignBlindsAndButton(table: Table): boolean {
       const p = table.seats[idx];
       if (!p) continue;
       if (p.state === PlayerState.ACTIVE) {
+        if (blind === "SB" && p.missedBigBlind) {
+          continue;
+        }
         if (
           table.deadBlindRule === DeadBlindRule.WAIT &&
           (p.missedBigBlind || p.missedSmallBlind)
@@ -164,8 +167,15 @@ export function assignBlindsAndButton(table: Table): boolean {
       sb = btn;
       bb = activeSeat(btn + 1, "BB");
     } else {
-      sb = activeSeat(btn + 1, "SB");
-      bb = sb !== null ? activeSeat(sb + 1, "BB") : null;
+      const first = (btn + 1) % table.seats.length;
+      const firstSeat = table.seats[first];
+      if (firstSeat?.state !== PlayerState.ACTIVE || firstSeat.missedBigBlind) {
+        sb = btn;
+        bb = activeSeat(btn + 1, "BB");
+      } else {
+        sb = activeSeat(btn + 1, "SB");
+        bb = sb !== null ? activeSeat(sb + 1, "BB") : null;
+      }
     }
   };
 

--- a/packages/nextjs/backend/room.ts
+++ b/packages/nextjs/backend/room.ts
@@ -245,4 +245,5 @@ export function payout(room: GameRoom, winners: PlayerSession[]) {
     }
   }
   room.pot = 0;
+  room.players = room.players.filter((p) => p.chips > 0);
 }


### PR DESCRIPTION
## Summary
- Prevent players who owe the big blind from taking the small blind, including handling empty seats next to the button
- Remove players with zero chips from the room after payouts

## Testing
- `yarn format:check`
- `yarn next:lint` *(fails: Failed to load parser './parser.js')*
- `yarn next:check-types` *(fails: JSX element implicitly has type 'any', missing modules)*
- `yarn test:nextjs` *(fails: 3 tests failing in blind assignment, betting engine, room payouts)*
- `yarn test` *(fails: command not found: snforge)*

------
https://chatgpt.com/codex/tasks/task_e_68a8489d2a808324aa731883f682fa3a