### PR TITLE
fix: use esm export for postcss config

### DIFF
--- a/packages/nextjs/postcss.config.js
+++ b/packages/nextjs/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- use ESM export in PostCSS config to support `type: module`

## Testing
- `yarn build` *(fails: Cannot read properties of undefined (reading 'EMPTY'))*
- `yarn next:lint` *(fails: Failed to load parser './parser.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a97b66fe208324ac428db05247da5a