### PR TITLE
fix backend exports and resolve naming conflicts

### DIFF
--- a/docs/dealing-and-betting.md
+++ b/docs/dealing-and-betting.md
@@ -53,7 +53,7 @@ A betting round ends when any of the following occurs:
 - All players are all‑in; the remaining board cards are dealt without further betting and the hand proceeds to showdown.
 
 ```pseudo
-function isRoundComplete():
+function isBettingRoundComplete():
   active = players.filter(p => p.state in {ACTIVE, ALL_IN})
   if active.count <= 1: return true
   if active.every(p => p.state == ALL_IN): return true

--- a/docs/game-states.md
+++ b/docs/game-states.md
@@ -140,7 +140,7 @@ End of hand:
 
 - At least two active players who can post blinds or are allowed to post all-in blinds.
 - Button assigned to the next active seat from the previous hand; for the first hand, choose a random active seat.
-- The `startHand` helper posts blinds, shuffles a fresh deck and deals two
+- The `startTableHand` helper posts blinds, shuffles a fresh deck and deals two
   hole cards to each active seat. If blinds cannot be posted the table falls
   back to **WAITING**.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -14,7 +14,7 @@ rounds progress, see [`dealing-and-betting.md`](./dealing-and-betting.md) and
 | Module | Responsibility |
 | --- | --- |
 | **TableManager** | Orchestrates the hand lifecycle and table state machine, rotating through **ROTATE** and **CLEANUP** after payouts while enforcing the minimum number of active players. |
-| **HandLifecycle** | Provides `startHand`/`endHand` helpers, resolves showdowns and splits pots, and calls `resetTableForNextHand` to rotate the button and prepare a fresh deal. |
+| **HandLifecycle** | Provides `startTableHand`/`endHand` helpers, resolves showdowns and splits pots, and calls `resetTableForNextHand` to rotate the button and prepare a fresh deal. |
 | **SeatingManager** | Handles seat assignment, buy‑in/top‑up, sit‑out/return and leave actions. Voluntary sit-outs take effect after the current hand. At hand end, broke players are marked `SITTING_OUT` if re‑buy is allowed or `LEAVING` when it is not. |
 | **BlindManager** | Assigns blind positions, auto‑posts blinds (allowing all‑in when short), enforces heads‑up order and applies configurable dead‑blind rules for returning players. |
 | **Dealer** | Shuffles the deck, deals hole and board cards (with optional burns) and keeps card visibility authoritative on the server. |
@@ -79,7 +79,7 @@ These checks keep the server authoritative and ensure that illegal actions are r
 #### Round Completion
 
 ```pseudo
-function isRoundComplete():
+function isBettingRoundComplete():
   active = players.filter(p => p.state in {ACTIVE, ALL_IN})
   if active.count <= 1: return true  // hand ends
   if active.every(p => p.state == ALL_IN): return true  // proceed to next street/showdown

--- a/packages/nextjs/backend/bettingEngine.ts
+++ b/packages/nextjs/backend/bettingEngine.ts
@@ -200,7 +200,7 @@ function nextToAct(table: Table, from: number): number | null {
 }
 
 /** Determine if betting round is complete */
-export function isRoundComplete(table: Table): boolean {
+export function isBettingRoundComplete(table: Table): boolean {
   const active = table.seats.filter(
     (p): p is Player =>
       !!p && (p.state === PlayerState.ACTIVE || p.state === PlayerState.ALL_IN),

--- a/packages/nextjs/backend/gameEngine.ts
+++ b/packages/nextjs/backend/gameEngine.ts
@@ -7,11 +7,11 @@ import {
 import {
   createRoom as createRoomImpl,
   addPlayer as addPlayerImpl,
-  startHand as startHandImpl,
+  startRoomHand as startHandImpl,
   handleAction as handleActionImpl,
   progressStage as progressStageImpl,
   determineWinners as determineWinnersImpl,
-  isRoundComplete as isRoundCompleteImpl,
+  isRoomRoundComplete as isRoundCompleteImpl,
   payout as payoutImpl,
 } from './room';
 import { PokerStateMachine, GameState } from './stateMachine';

--- a/packages/nextjs/backend/handLifecycle.ts
+++ b/packages/nextjs/backend/handLifecycle.ts
@@ -15,7 +15,7 @@ import crypto from "crypto";
  * `false` when the hand cannot begin (e.g. not enough active
  * players or blinds could not be posted).
  */
-export function startHand(table: Table, audit?: AuditLogger): boolean {
+export function startTableHand(table: Table, audit?: AuditLogger): boolean {
   if (table.state !== TableState.BLINDS) return false;
   if (countActivePlayers(table) < 2) {
     table.state = TableState.WAITING;
@@ -64,4 +64,3 @@ export async function endHand(table: Table, audit?: AuditLogger) {
   await resetTableForNextHand(table);
 }
 
-export default { startHand, endHand };

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -1,5 +1,6 @@
 export * from "./stateMachine";
 export * from "./constants";
+export { PlayerState } from "./types";
 export type {
   Suit,
   Rank,
@@ -10,7 +11,6 @@ export type {
   UiPlayer,
   GameState as EngineGameState,
   CardShape,
-  PlayerState,
   PlayerAction,
   Player,
   TableState,
@@ -23,7 +23,16 @@ export type {
 } from "./types";
 export type { ServerEvent, ClientCommand } from "./networking";
 export * from "./utils";
-export * from "./room";
+export {
+  createRoom,
+  addPlayer,
+  handleAction,
+  nextTurn,
+  determineWinners,
+  isRoomRoundComplete,
+  payout,
+  startRoomHand,
+} from "./room";
 export * from "./hashEvaluator";
 export * from "./handEvaluator";
 export * from "./rng";
@@ -34,9 +43,14 @@ export * from "./eventBus";
 export * from "./playerStateMachine";
 export * from "./tableStateMachine";
 export * from "./dealer";
-export * from "./bettingEngine";
+export {
+  startBettingRound,
+  applyAction,
+  applyActionFromJson,
+  isBettingRoundComplete,
+} from "./bettingEngine";
 export * from "./potManager";
 export * from "./timerService";
 export * from "./handReset";
-export * from "./handLifecycle";
+export { startTableHand, endHand } from "./handLifecycle";
 export * from "./auditLogger";

--- a/packages/nextjs/backend/room.ts
+++ b/packages/nextjs/backend/room.ts
@@ -42,8 +42,12 @@ export function addPlayer(
   return session;
 }
 
-/** Start a new hand and deal cards. Requires at least two players. */
-export function startHand(room: GameRoom) {
+/**
+ * Start a new hand at the room level and deal cards. Requires at least
+ * two players to be seated with chips. Updates dealer/button positions
+ * and posts blinds via {@link BlindManager}.
+ */
+export function startRoomHand(room: GameRoom) {
   if (room.players.length < 2) {
     room.stage = "waiting";
     return;
@@ -209,8 +213,12 @@ export function determineWinners(room: GameRoom): PlayerSession[] {
   return evaluated.filter((e) => e.score === best).map((e) => e.player);
 }
 
-/** Check if the current betting round is complete */
-export function isRoundComplete(room: GameRoom): boolean {
+/**
+ * Determine if the current betting round within a room is complete.
+ * A round is complete when all active players have matched the highest bet
+ * or are all-in, and the turn has returned to the appropriate player.
+ */
+export function isRoomRoundComplete(room: GameRoom): boolean {
   const active = room.players.filter((p) => !p.hasFolded);
   if (active.length <= 1) return true;
   if (active.every((p) => p.chips === 0)) return true;

--- a/packages/nextjs/backend/tableManager.ts
+++ b/packages/nextjs/backend/tableManager.ts
@@ -1,9 +1,9 @@
 import { Table, PlayerAction, Round, TableState } from "./types";
 import { TableStateMachine } from "./tableStateMachine";
-import { startHand as startHandLifecycle, endHand } from "./handLifecycle";
+import { startTableHand as startHandLifecycle, endHand } from "./handLifecycle";
 import {
   applyAction,
-  isRoundComplete,
+  isBettingRoundComplete,
   startBettingRound,
 } from "./bettingEngine";
 import { dealBoard } from "./dealer";
@@ -45,7 +45,7 @@ export class TableManager {
     action: { type: PlayerAction; amount?: number },
   ) {
     applyAction(this.table, seatIndex, action, this.audit);
-    if (!isRoundComplete(this.table)) return;
+    if (!isBettingRoundComplete(this.table)) return;
 
     const remaining = countActivePlayers(this.table);
     this.fsm.dispatch({

--- a/packages/nextjs/backend/tests/bettingEngineJson.test.ts
+++ b/packages/nextjs/backend/tests/bettingEngineJson.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { applyActionFromJson } from '../bettingEngine';
-import { isRoundComplete } from '../bettingEngine';
+import { isBettingRoundComplete } from '../bettingEngine';
 import { tableFromJson } from '../jsonFormats';
 import type { BettingActionRequest } from '../jsonFormats';
 
@@ -27,6 +27,6 @@ describe('BettingEngine JSON interface', () => {
     }
     const finalTable = tableFromJson(jsonTable);
     expect(finalTable.actingIndex).toBe(data.expected.actingIndex);
-    expect(isRoundComplete(finalTable)).toBe(true);
+    expect(isBettingRoundComplete(finalTable)).toBe(true);
   });
 });

--- a/packages/nextjs/backend/tests/dealerBetting.test.ts
+++ b/packages/nextjs/backend/tests/dealerBetting.test.ts
@@ -9,7 +9,11 @@ import {
 } from '../types';
 import { dealHole } from '../dealer';
 import { assignBlindsAndButton } from '../blindManager';
-import { startBettingRound, applyAction, isRoundComplete } from '../bettingEngine';
+import {
+  startBettingRound,
+  applyAction,
+  isBettingRoundComplete,
+} from '../bettingEngine';
 
 const card = (rank: string, suit: string) => ({ rank: rank as any, suit: suit as any });
 const createPlayer = (id: string, seatIndex: number, stack: number): Player => ({
@@ -106,7 +110,7 @@ describe('Dealer & BettingEngine', () => {
     expect(table.betToCall).toBe(40);
     expect(table.minRaise).toBe(20);
     applyAction(table,1,{type:PlayerAction.CALL});
-    expect(isRoundComplete(table)).toBe(true);
+    expect(isBettingRoundComplete(table)).toBe(true);
     expect(table.actingIndex).toBeNull();
   });
 
@@ -152,7 +156,7 @@ describe('Dealer & BettingEngine', () => {
     ).toThrow();
 
     applyAction(table,0,{type:PlayerAction.CALL});
-    expect(isRoundComplete(table)).toBe(true);
+    expect(isBettingRoundComplete(table)).toBe(true);
   });
 
   it('blocks earlier callers from re-raising after short all-in', () => {
@@ -194,7 +198,7 @@ describe('Dealer & BettingEngine', () => {
     applyAction(table,0,{type:PlayerAction.CALL});
     expect(() => applyAction(table,1,{type:PlayerAction.RAISE, amount:20})).toThrow();
     applyAction(table,1,{type:PlayerAction.CALL});
-    expect(isRoundComplete(table)).toBe(true);
+    expect(isBettingRoundComplete(table)).toBe(true);
   });
 
   it('rejects invalid checks without changing turn', () => {

--- a/packages/nextjs/backend/tests/handLifecycle.test.ts
+++ b/packages/nextjs/backend/tests/handLifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { startHand, endHand } from '../handLifecycle';
+import { startTableHand, endHand } from '../handLifecycle';
 import {
   Table,
   Player,
@@ -59,7 +59,7 @@ describe('handLifecycle', () => {
       createPlayer('a', 0, 100),
       createPlayer('b', 1, 100),
     ]);
-    const ok = startHand(table);
+    const ok = startTableHand(table);
     expect(ok).toBe(true);
     expect(table.state).toBe(TableState.PRE_FLOP);
     expect(table.seats[0]?.holeCards.length).toBe(2);

--- a/packages/nextjs/backend/tests/room.test.ts
+++ b/packages/nextjs/backend/tests/room.test.ts
@@ -5,9 +5,9 @@ import {
   handleAction,
   nextTurn,
   determineWinners,
-  isRoundComplete,
+  isRoomRoundComplete,
   payout,
-  startHand,
+  startRoomHand,
   BlindManager,
 } from "..";
 import { describe, it } from "vitest";
@@ -15,14 +15,14 @@ import { describe, it } from "vitest";
 // Comprehensive integration test for core room helpers
 describe("room helpers", () => {
   it("handles hand flow and payouts", () => {
-    // startHand should begin only when at least two players are seated
+    // startRoomHand should begin only when at least two players are seated
     const startRoom = createRoom("start");
     addPlayer(startRoom, { id: "a", nickname: "A", seat: 0, chips: 100 });
-    startHand(startRoom);
+    startRoomHand(startRoom);
     assert.strictEqual(startRoom.stage, "waiting");
 
     addPlayer(startRoom, { id: "b", nickname: "B", seat: 1, chips: 100 });
-    startHand(startRoom);
+    startRoomHand(startRoom);
     assert.strictEqual(startRoom.stage, "preflop");
     startRoom.players.forEach((p) => assert.strictEqual(p.hand.length, 2));
 
@@ -121,7 +121,7 @@ describe("room helpers", () => {
     assert.strictEqual(showdownRoom.pot, 0);
     assert.strictEqual(winners[0].chips, 100);
 
-    assert.ok(isRoundComplete(room));
+    assert.ok(isRoomRoundComplete(room));
 
     // payout remainder test
     const remainderRoom = {

--- a/packages/nextjs/server/index.ts
+++ b/packages/nextjs/server/index.ts
@@ -1,5 +1,10 @@
 import { WebSocketServer, WebSocket } from "ws";
-import { createRoom, addPlayer, handleAction, startHand } from "../backend";
+import {
+  createRoom,
+  addPlayer,
+  handleAction,
+  startRoomHand,
+} from "../backend";
 import type {
   GameRoom,
   ServerEvent,
@@ -111,7 +116,7 @@ wss.on("connection", (ws) => {
           });
           session.roomId = room.id;
           if (room.players.length >= 2 && room.stage === "waiting") {
-            startHand(room);
+            startRoomHand(room);
             broadcast(room.id, { type: "HAND_START" });
           }
           broadcast(room.id, { type: "TABLE_SNAPSHOT", table: room });


### PR DESCRIPTION
## Summary
- re-export PlayerState as runtime value and explicitly surface backend helpers to avoid star-export collisions
- rename room helpers to startRoomHand and isRoomRoundComplete for clearer module boundaries
- document new betting round completion helper and hand lifecycle entrypoint

## Testing
- `yarn test:nextjs` (fails: blindsTable.test.ts, dealerBetting.test.ts, room.test.ts)
- `yarn build` (succeeds generating static pages but ends with unhandled TypeError from rimraf)


------
https://chatgpt.com/codex/tasks/task_e_68a982347268832488fc59254e3d5149