### PR TITLE
feat: enforce 10s action timeout

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -48,7 +48,7 @@ Describes the state of the table for the current hand.
 | `actingIndex` | Seat whose turn it is or `null` when idle |
 | `betToCall` | Highest commitment to match in the current round |
 | `minRaise` | Minimum raise size per no‑limit rules |
-| `actionTimer` | Default action time in milliseconds (≈15,000 by default) |
+| `actionTimer` | Default action time in milliseconds (≈10,000 by default) |
 | `interRoundDelayMs` / `dealAnimationDelayMs` | Delay before starting the next hand (≈1–3s) / card deal animation timing (≈400–800ms) |
 | `rakeConfig` | Optional rake percentage, cap and minimum |
 | `deadBlindRule` | Strategy for handling missed blinds: `POST` or `WAIT` |

--- a/docs/dealing-and-betting.md
+++ b/docs/dealing-and-betting.md
@@ -88,7 +88,7 @@ function rebuildPots():
 - If all but one player folds at any point, that player wins the pot immediately and no further streets are dealt.
 - Short all-in raises that do not meet the current `minRaise` never reopen the betting; players who already acted may only call or fold.
 - Invalid actions (for example, trying to check when `betToCall > 0`) are rejected and the turn timer continues to run.
-- When a player's `actionTimer` (typically around 15s) expires, they automatically check if `betToCall` is `0` or fold otherwise.
+- When a player's `actionTimer` (typically around 10s) expires, they automatically check if `betToCall` is `0` or fold otherwise.
 - The server serializes simultaneous inputs and only accepts commands from the current `actingIndex`.
 - When a player disconnects during their turn, a separate grace timer runs. When it elapses the player's remaining `timebankMs` is consumed before an automatic fold or check is applied.
 - After payouts the dealer button moves to the next active seat clockwise. Players returning from sitting out must either post any missed blinds immediately (`deadBlindRule = POST`) or wait for the big blind to reach them (`deadBlindRule = WAIT`). When the small-blind seat is empty the blinds roll forward to the next available active players.

--- a/packages/nextjs/backend/constants.ts
+++ b/packages/nextjs/backend/constants.ts
@@ -25,6 +25,9 @@ export const SUITS: Suit[] = ['s', 'h', 'd', 'c'];
 export const SMALL_BLIND = 5;
 export const BIG_BLIND = 10;
 
+/** Default time (ms) a player has to act before auto-check/fold */
+export const ACTION_TIMEOUT_MS = 10_000;
+
 /** Streets in order */
 export const STREETS = [
   'preflop',

--- a/packages/nextjs/backend/tests/timerService.test.ts
+++ b/packages/nextjs/backend/tests/timerService.test.ts
@@ -49,6 +49,20 @@ const createTable = (player: Player, extra: Partial<Table> = {}): Table => ({
 });
 
 describe("TimerService", () => {
+  it("defaults to 10s when actionTimer is zero", () => {
+    vi.useFakeTimers();
+    const player = createPlayer("p1", 0);
+    const table = createTable(player, { betToCall: 0, actionTimer: 0 });
+    const onAutoAction = vi.fn();
+    const timers = new TimerService(table, { onAutoAction });
+    timers.startActionTimer(player);
+    vi.advanceTimersByTime(9999);
+    expect(onAutoAction).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onAutoAction).toHaveBeenCalledWith("p1", PlayerAction.CHECK);
+    vi.useRealTimers();
+  });
+
   it("auto-checks when no bet to call", () => {
     vi.useFakeTimers();
     const player = createPlayer("p1", 0);

--- a/packages/nextjs/backend/timerService.ts
+++ b/packages/nextjs/backend/timerService.ts
@@ -1,5 +1,6 @@
 import { Player, PlayerAction, PlayerState, Table, Round } from './types';
 import { draw } from './utils';
+import { ACTION_TIMEOUT_MS } from './constants';
 
 /** Handlers invoked when timers resolve to auto actions */
 export interface TimerHandlers {
@@ -47,7 +48,7 @@ export class TimerService {
       } else {
         forceAction();
       }
-    }, this.table.actionTimer);
+    }, this.table.actionTimer || ACTION_TIMEOUT_MS);
   }
 
   /** Handle player disconnection with a grace timer */


### PR DESCRIPTION
## Summary
- default player action timer to 10 seconds
- auto-check/fold after countdown expires
- document 10s action timeout and add coverage test

## Testing
- `yarn next:lint` *(fails: eslint-config-next missing peer dep)*
- `yarn next:check-types` *(fails: many modules missing)*
- `yarn test:nextjs` *(fails: blindsTable, dealerBetting, room tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a98be4dc8883249573f8c2d9744a01