### PR TITLE
feat: add session-based user addresses

### DIFF
--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import Card from "./Card";
 import type { UiPlayer, Card as TCard } from "../backend";
 import { PlayerState } from "../backend";
+import { shortAddress } from "../utils/address";
 
 interface PlayerSeatProps {
   player: UiPlayer; // player object from your Zustand store
@@ -72,7 +73,9 @@ export default function PlayerSeat({
             : "bg-black/60 border-gray-500 hover:bg-red-500 hover:border-red-500",
         )}
       >
-        <span className="text-[var(--color-highlight)]">{player.name}</span>
+        <span className="text-[var(--color-highlight)]">
+          {shortAddress(player.name)}
+        </span>
       </div>
       {state === PlayerState.ALL_IN && (
         <span className="absolute -bottom-5 left-1/2 -translate-x-1/2 text-xs text-yellow-300 font-bold">

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "next-themes";
 import { BlockieAvatar } from "../BlockieAvatar";
 import GenericModal from "./GenericModal";
 import { LAST_CONNECTED_TIME_LOCALSTORAGE_KEY } from "~~/utils/Constants";
+import { randomAddress } from "~~/utils/address";
 
 const loader = ({ src }: { src: string }) => {
   return src;
@@ -64,6 +65,13 @@ const ConnectModal = () => {
     }
   }
 
+  function handleDemoPlayer() {
+    const addr = randomAddress();
+    localStorage.setItem("sessionId", addr);
+    handleCloseModal();
+    window.location.reload();
+  }
+
   return (
     <div>
       <label
@@ -96,14 +104,22 @@ const ConnectModal = () => {
           <div className="flex flex-col flex-1 lg:grid">
             <div className="flex flex-col gap-4 w-full px-8 py-10">
               {!isBurnerWallet ? (
-                connectors.map((connector, index) => (
-                  <Wallet
-                    key={connector.id || index}
-                    connector={connector}
-                    loader={loader}
-                    handleConnectWallet={handleConnectWallet}
-                  />
-                ))
+                <>
+                  {connectors.map((connector, index) => (
+                    <Wallet
+                      key={connector.id || index}
+                      connector={connector}
+                      loader={loader}
+                      handleConnectWallet={handleConnectWallet}
+                    />
+                  ))}
+                  <button
+                    className="mt-2 py-2 px-4 rounded border border-gray-500 hover:bg-gradient-modal"
+                    onClick={handleDemoPlayer}
+                  >
+                    Demo Player
+                  </button>
+                </>
               ) : (
                 <div className="flex flex-col pb-[20px] justify-end gap-3">
                   <div className="h-[300px] overflow-y-auto flex w-full flex-col gap-2">

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
@@ -32,6 +32,12 @@ export const CustomConnectButton = () => {
     );
   }, [accountAddress, targetNetwork]);
 
+  useEffect(() => {
+    if (accountAddress) {
+      localStorage.setItem("sessionId", accountAddress);
+    }
+  }, [accountAddress]);
+
   // effect to get chain id and address from account
   useEffect(() => {
     if (account) {

--- a/packages/nextjs/hooks/useGameStore.ts
+++ b/packages/nextjs/hooks/useGameStore.ts
@@ -7,6 +7,7 @@ import {
   PlayerState,
 } from "../backend";
 import type { Stage } from "../backend";
+import { shortAddress } from "../utils/address";
 
 /** Map Stage strings to numeric street indices used by the UI */
 const stageToStreet: Record<Stage, number> = {
@@ -156,19 +157,22 @@ export const useGameStore = create<GameStoreState>((set, get) => {
     });
   },
 
-  /** Seat a demo player at the given index */
+  /** Seat a player using the stored session address */
   joinSeat: async (seatIdx: number) => {
     const room = engine.getState();
     // prevent double seating
     if (room.players.some((p) => p.seat === seatIdx)) return;
+    const id =
+      typeof window !== "undefined" ? localStorage.getItem("sessionId") : null;
+    const nickname = id ? shortAddress(id) : `Player ${seatIdx + 1}`;
     engine.addPlayer({
-      id: `p${seatIdx}`,
-      nickname: `Player ${seatIdx + 1}`,
+      id: id || `p${seatIdx}`,
+      nickname,
       seat: seatIdx,
       chips: 10000,
     });
     await get().reloadTableState();
-    get().addLog(`Player ${seatIdx + 1} joined`);
+    get().addLog(`${nickname} joined`);
   },
 
   /** Deal new hole cards to all players */

--- a/packages/nextjs/utils/address.ts
+++ b/packages/nextjs/utils/address.ts
@@ -1,0 +1,16 @@
+export function randomAddress(): string {
+  const bytes = new Uint8Array(20);
+  if (typeof window !== "undefined" && window.crypto && window.crypto.getRandomValues) {
+    window.crypto.getRandomValues(bytes);
+  } else {
+    // fallback for server-side rendering
+    const { randomFillSync } = require("crypto");
+    randomFillSync(bytes);
+  }
+  return "0x" + Array.from(bytes, b => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function shortAddress(addr: string): string {
+  if (addr.length <= 10) return addr;
+  return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary
- allow demo players by generating random wallet addresses
- persist connected wallet address as session id
- show table names as shortened addresses

## Testing
- `yarn test:nextjs` *(fails: expected 1 to be +0, etc.)*
- `yarn next:lint` *(fails: Failed to load parser './parser.js')*
- `yarn format:check` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68a99636ac308324bb4fdb98b7f493c1