### PR TITLE
feat: add demo player option

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -8,6 +8,8 @@ import DealerWindow from "../../components/DealerWindow";
 import { CustomConnectButton } from "../../components/scaffold-stark/CustomConnectButton";
 import ActionBar from "../../components/ActionBar";
 import { usePlayViewModel } from "../../hooks/usePlayViewModel";
+import { randomAddress } from "../../utils/address";
+import { useAccount } from "@starknet-react/core";
 
 // TODO: display connected address and handle signature (Action Plan 1.3)
 
@@ -24,6 +26,13 @@ export default function PlayPage() {
     socket,
     sessionId,
   } = usePlayViewModel();
+  const { status } = useAccount();
+
+  function handleDemoPlayer() {
+    const addr = randomAddress();
+    localStorage.setItem("sessionId", addr);
+    window.location.reload();
+  }
 
   return (
     <main
@@ -37,8 +46,18 @@ export default function PlayPage() {
     >
       <header className="relative w-full flex items-center mt-6 mb-4 px-4">
         <AnimatedTitle text="Poker Night on Starknet" />
-        <div className="flex flex-1 items-center justify-end gap-4">
-          <CustomConnectButton />
+        <div className="flex flex-1 items-center justify-end">
+          <div className="flex flex-col items-end gap-2">
+            <CustomConnectButton />
+            {status === "disconnected" && (
+              <button
+                className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance border border-gray-500 hover:bg-gradient-nav hover:text-white"
+                onClick={handleDemoPlayer}
+              >
+                Demo Player
+              </button>
+            )}
+          </div>
           {/* TODO: persist session token and auto-reconnect (Action Plan 1.3) */}
         </div>
       </header>

--- a/packages/nextjs/server/index.ts
+++ b/packages/nextjs/server/index.ts
@@ -12,11 +12,7 @@ import type {
   PlayerAction,
 } from "../backend";
 import { SessionManager, Session } from "./sessionManager";
-
-function shortAddress(addr: string): string {
-  if (addr.length <= 8) return addr;
-  return `${addr.slice(0, 4)}..${addr.slice(-4)}`;
-}
+import { shortAddress } from "../utils/address";
 
 const wss = new WebSocketServer({ port: 8080 });
 const sessions = new SessionManager();

--- a/packages/nextjs/utils/address.ts
+++ b/packages/nextjs/utils/address.ts
@@ -12,5 +12,5 @@ export function randomAddress(): string {
 
 export function shortAddress(addr: string): string {
   if (addr.length <= 10) return addr;
-  return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+  return `${addr.slice(0, 5)}...${addr.slice(-4)}`;
 }


### PR DESCRIPTION
## Summary
- add Demo Player button to play page for walletless users
- show table nicknames in `0x***...****` format
- reuse shared shortAddress utility on websocket server

## Testing
- `yarn next:lint` *(fails: couldn't find Next parser dependency)*
- `yarn test:nextjs` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b9cfb1848324a32442b834149f12