### PR TITLE
feat: block mobile play with overlay message

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { ScaffoldStarkAppWithProviders } from "~~/components/ScaffoldStarkAppWithProviders";
 import "~~/styles/globals.css";
 import { ThemeProvider } from "~~/components/ThemeProvider";
+import MobileBlocker from "~~/components/MobileBlocker";
 
 export const metadata: Metadata = {
   title: "PokerNFTs",
@@ -22,6 +23,7 @@ const ScaffoldStarkApp = ({ children }: { children: React.ReactNode }) => {
         className="flex flex-col min-h-screen bg-main"
       >
         <ThemeProvider>
+          <MobileBlocker />
           <ScaffoldStarkAppWithProviders>
             {children}
           </ScaffoldStarkAppWithProviders>

--- a/packages/nextjs/components/MobileBlocker.tsx
+++ b/packages/nextjs/components/MobileBlocker.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import useIsMobile from "~~/hooks/useIsMobile";
+import { useScrollLock } from "~~/hooks/useScrollLock";
+
+const MobileBlocker = () => {
+  const isMobile = useIsMobile();
+  useScrollLock(isMobile);
+
+  if (!isMobile) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+      <div className="mx-4 rounded-md bg-white p-6 text-center text-black">
+        <p className="mb-2 text-lg font-semibold">
+          Mobile support is coming soon.
+        </p>
+        <p>Please use a desktop browser to play.</p>
+      </div>
+    </div>
+  );
+};
+
+export default MobileBlocker;
+


### PR DESCRIPTION
## Summary
- add MobileBlocker component to display message and lock scrolling on mobile
- hook MobileBlocker into layout for global coverage

## Testing
- `yarn test:nextjs` *(fails: AssertionError: expected 1 to be +0, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c477a5208324aea98217239adda5