### PR TITLE
Simulate wallet connection for demo players and restrict seating

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -49,7 +49,7 @@ export default function PlayPage() {
         <div className="flex flex-1 items-center justify-end">
           <div className="flex flex-col items-end gap-2">
             <CustomConnectButton />
-            {status === "disconnected" && (
+            {status === "disconnected" && !sessionId && (
               <button
                 className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance border border-gray-500 hover:bg-gradient-nav hover:text-white"
                 onClick={handleDemoPlayer}

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
@@ -5,6 +5,7 @@ import { Balance } from "../Balance";
 import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { WrongNetworkDropdown } from "./WrongNetworkDropdown";
+import { BlockieAvatar } from "../BlockieAvatar";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-stark";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-stark";
@@ -24,6 +25,9 @@ export const CustomConnectButton = () => {
   const { account, status, address: accountAddress } = useAccount();
   const [accountChainId, setAccountChainId] = useState<bigint>(0n);
   const { chain } = useNetwork();
+  const [demoAddress, setDemoAddress] = useState<string | null>(() =>
+    typeof window !== "undefined" ? localStorage.getItem("sessionId") : null,
+  );
 
   const blockExplorerAddressLink = useMemo(() => {
     return (
@@ -37,6 +41,18 @@ export const CustomConnectButton = () => {
       localStorage.setItem("sessionId", accountAddress);
     }
   }, [accountAddress]);
+
+  useEffect(() => {
+    if (status === "disconnected") {
+      const stored =
+        typeof window !== "undefined"
+          ? localStorage.getItem("sessionId")
+          : null;
+      setDemoAddress(stored);
+    } else {
+      setDemoAddress(null);
+    }
+  }, [status]);
 
   // effect to get chain id and address from account
   useEffect(() => {
@@ -65,8 +81,21 @@ export const CustomConnectButton = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connector]);
 
-  if (status === "disconnected" || accountChainId === 0n)
+  if (status === "disconnected") {
+    if (demoAddress) {
+      return (
+        <div className="btn bg-transparent btn-sm px-2 py-[0.35rem] gap-2 !h-auto border border-[#5c4fe5]">
+          <BlockieAvatar address={demoAddress} size={28} />
+          <span className="text-sm">
+            {demoAddress.slice(0, 6)}...{demoAddress.slice(-4)}
+          </span>
+        </div>
+      );
+    }
     return <ConnectModal />;
+  }
+
+  if (accountChainId === 0n) return <ConnectModal />;
 
   if (accountChainId !== targetNetwork.id) {
     return <WrongNetworkDropdown />;

--- a/packages/nextjs/hooks/useGameStore.ts
+++ b/packages/nextjs/hooks/useGameStore.ts
@@ -68,162 +68,169 @@ interface GameStoreState {
 }
 
 export const useGameStore = create<GameStoreState>((set, get) => {
-  engine.on('phaseChanged', (phase: EnginePhase) => set({ phase }));
-  engine.on('stateChanged', () => get().reloadTableState());
-  engine.on('handStarted', () => get().addLog('Dealer: Hand started'));
-  engine.on('stageChanged', (stage: Stage) => {
+  engine.on("phaseChanged", (phase: EnginePhase) => set({ phase }));
+  engine.on("stateChanged", () => get().reloadTableState());
+  engine.on("handStarted", () => get().addLog("Dealer: Hand started"));
+  engine.on("stageChanged", (stage: Stage) => {
     const msg =
-      stage === 'flop'
-        ? 'Dealer: Flop dealt'
-        : stage === 'turn'
-        ? 'Dealer: Turn dealt'
-        : stage === 'river'
-        ? 'Dealer: River dealt'
-        : '';
+      stage === "flop"
+        ? "Dealer: Flop dealt"
+        : stage === "turn"
+          ? "Dealer: Turn dealt"
+          : stage === "river"
+            ? "Dealer: River dealt"
+            : "";
     if (msg) get().addLog(msg);
   });
-  engine.on('handEnded', () => get().addLog('Dealer: Hand complete'));
+  engine.on("handEnded", () => get().addLog("Dealer: Hand complete"));
   return {
-  players: Array(9).fill(null),
-  playerHands: Array(9).fill(null),
-  community: Array(5).fill(null),
-  chips: Array(9).fill(0),
-  playerBets: Array(9).fill(0),
-  playerStates: Array(9).fill(PlayerState.EMPTY),
-  pot: 0,
-  currentTurn: null,
-  street: 0,
-  phase: engine.getPhase(),
-  loading: false,
-  error: null,
-  logs: [],
-  addLog: (msg) => set((s) => ({ logs: [...s.logs, msg] })),
-  smallBlind: 25,
-  bigBlind: 50,
-  startBlindTimer: () => {
-    const increase = () =>
-      set((s) => ({
-        smallBlind: s.smallBlind * 2,
-        bigBlind: s.bigBlind * 2,
-      }));
-    setTimeout(function tick() {
-      increase();
-      setTimeout(tick, 10 * 60 * 1000);
-    }, 10 * 60 * 1000);
-  },
+    players: Array(9).fill(null),
+    playerHands: Array(9).fill(null),
+    community: Array(5).fill(null),
+    chips: Array(9).fill(0),
+    playerBets: Array(9).fill(0),
+    playerStates: Array(9).fill(PlayerState.EMPTY),
+    pot: 0,
+    currentTurn: null,
+    street: 0,
+    phase: engine.getPhase(),
+    loading: false,
+    error: null,
+    logs: [],
+    addLog: (msg) => set((s) => ({ logs: [...s.logs, msg] })),
+    smallBlind: 25,
+    bigBlind: 50,
+    startBlindTimer: () => {
+      const increase = () =>
+        set((s) => ({
+          smallBlind: s.smallBlind * 2,
+          bigBlind: s.bigBlind * 2,
+        }));
+      setTimeout(
+        function tick() {
+          increase();
+          setTimeout(tick, 10 * 60 * 1000);
+        },
+        10 * 60 * 1000,
+      );
+    },
 
-  /** Sync Zustand state from the current room object */
-  reloadTableState: async () => {
-    const room = engine.getState();
-    const seats = Array(9).fill(null) as (string | null)[];
-    const hands = Array(9).fill(null) as ([number, number] | null)[];
-    const chips = Array(9).fill(0) as number[];
-    const bets = Array(9).fill(0) as number[];
-    const states = Array(9).fill(PlayerState.EMPTY) as PlayerState[];
-    room.players.forEach((p) => {
-      seats[p.seat] = p.nickname;
-      if (p.hand.length === 2) {
-        hands[p.seat] = [cardToIndex(p.hand[0]), cardToIndex(p.hand[1])];
+    /** Sync Zustand state from the current room object */
+    reloadTableState: async () => {
+      const room = engine.getState();
+      const seats = Array(9).fill(null) as (string | null)[];
+      const hands = Array(9).fill(null) as ([number, number] | null)[];
+      const chips = Array(9).fill(0) as number[];
+      const bets = Array(9).fill(0) as number[];
+      const states = Array(9).fill(PlayerState.EMPTY) as PlayerState[];
+      room.players.forEach((p) => {
+        seats[p.seat] = p.nickname;
+        if (p.hand.length === 2) {
+          hands[p.seat] = [cardToIndex(p.hand[0]), cardToIndex(p.hand[1])];
+        }
+        chips[p.seat] = p.chips;
+        bets[p.seat] = p.currentBet;
+        let state = PlayerState.ACTIVE;
+        if (p.hasFolded) state = PlayerState.FOLDED;
+        else if (p.chips === 0) state = PlayerState.ALL_IN;
+        states[p.seat] = state;
+      });
+
+      const comm = Array(5).fill(null) as (number | null)[];
+      room.communityCards.forEach((c, i) => {
+        comm[i] = cardToIndex(c);
+      });
+
+      set({
+        players: seats,
+        playerHands: hands,
+        community: comm,
+        chips,
+        playerBets: bets,
+        playerStates: states,
+        pot: room.pot,
+        currentTurn:
+          room.players.length && room.players[room.currentTurnIndex]?.isTurn
+            ? room.players[room.currentTurnIndex].seat
+            : null,
+        street: stageToStreet[room.stage],
+        phase: engine.getPhase(),
+        loading: false,
+        error: null,
+      });
+    },
+
+    /** Seat a player using the stored session address */
+    joinSeat: async (seatIdx: number) => {
+      const room = engine.getState();
+      // prevent double seating or multiple seats per user
+      if (room.players.some((p) => p.seat === seatIdx)) return;
+      const id =
+        typeof window !== "undefined"
+          ? localStorage.getItem("sessionId")
+          : null;
+      if (!id) return;
+      if (room.players.some((p) => p.id === id)) return;
+      const nickname = shortAddress(id);
+      engine.addPlayer({
+        id,
+        nickname,
+        seat: seatIdx,
+        chips: 10000,
+      });
+      await get().reloadTableState();
+      get().addLog(`${nickname} joined`);
+    },
+
+    /** Deal new hole cards to all players */
+    startHand: async () => {
+      engine.startHand();
+      await get().reloadTableState();
+    },
+
+    /** Reveal the flop (dev control) */
+    dealFlop: async () => {
+      if (engine.getState().stage === "preflop") {
+        engine.progressStage();
       }
-      chips[p.seat] = p.chips;
-      bets[p.seat] = p.currentBet;
-      let state = PlayerState.ACTIVE;
-      if (p.hasFolded) state = PlayerState.FOLDED;
-      else if (p.chips === 0) state = PlayerState.ALL_IN;
-      states[p.seat] = state;
-    });
+    },
 
-    const comm = Array(5).fill(null) as (number | null)[];
-    room.communityCards.forEach((c, i) => {
-      comm[i] = cardToIndex(c);
-    });
+    /** Reveal the turn (dev control) */
+    dealTurn: async () => {
+      if (engine.getState().stage === "flop") {
+        engine.progressStage();
+      }
+    },
 
-    set({
-      players: seats,
-      playerHands: hands,
-      community: comm,
-      chips,
-      playerBets: bets,
-      playerStates: states,
-      pot: room.pot,
-      currentTurn:
-        room.players.length && room.players[room.currentTurnIndex]?.isTurn
-          ? room.players[room.currentTurnIndex].seat
-          : null,
-      street: stageToStreet[room.stage],
-      phase: engine.getPhase(),
-      loading: false,
-      error: null,
-    });
-  },
+    /** Reveal the river (dev control) */
+    dealRiver: async () => {
+      if (engine.getState().stage === "turn") {
+        engine.progressStage();
+      }
+    },
 
-  /** Seat a player using the stored session address */
-  joinSeat: async (seatIdx: number) => {
-    const room = engine.getState();
-    // prevent double seating
-    if (room.players.some((p) => p.seat === seatIdx)) return;
-    const id =
-      typeof window !== "undefined" ? localStorage.getItem("sessionId") : null;
-    const nickname = id ? shortAddress(id) : `Player ${seatIdx + 1}`;
-    engine.addPlayer({
-      id: id || `p${seatIdx}`,
-      nickname,
-      seat: seatIdx,
-      chips: 10000,
-    });
-    await get().reloadTableState();
-    get().addLog(`${nickname} joined`);
-  },
-
-  /** Deal new hole cards to all players */
-  startHand: async () => {
-    engine.startHand();
-    await get().reloadTableState();
-  },
-
-  /** Reveal the flop (dev control) */
-  dealFlop: async () => {
-    if (engine.getState().stage === 'preflop') {
-      engine.progressStage();
-    }
-  },
-
-  /** Reveal the turn (dev control) */
-  dealTurn: async () => {
-    if (engine.getState().stage === 'flop') {
-      engine.progressStage();
-    }
-  },
-
-  /** Reveal the river (dev control) */
-  dealRiver: async () => {
-    if (engine.getState().stage === 'turn') {
-      engine.progressStage();
-    }
-  },
-
-  /** Apply a betting action for the current turn player */
-  playerAction: async (action) => {
-    const room = engine.getState();
-    const current = room.players[room.currentTurnIndex];
-    engine.handleAction(current.id, action);
-    const acted = engine.getState().players.find((p) => p.id === current.id)!;
-    let msg = '';
-    switch (action.type) {
-      case 'fold':
-        msg = `${acted.nickname} folds`;
-        break;
-      case 'check':
-        msg = `${acted.nickname} checks`;
-        break;
-      case 'call':
-        msg = `${acted.nickname} calls ${acted.currentBet}`;
-        break;
-      case 'raise':
-        msg = `${acted.nickname} bets ${action.amount ?? acted.currentBet}`;
-        break;
-    }
-    get().addLog(msg);
-  },
+    /** Apply a betting action for the current turn player */
+    playerAction: async (action) => {
+      const room = engine.getState();
+      const current = room.players[room.currentTurnIndex];
+      engine.handleAction(current.id, action);
+      const acted = engine.getState().players.find((p) => p.id === current.id)!;
+      let msg = "";
+      switch (action.type) {
+        case "fold":
+          msg = `${acted.nickname} folds`;
+          break;
+        case "check":
+          msg = `${acted.nickname} checks`;
+          break;
+        case "call":
+          msg = `${acted.nickname} calls ${acted.currentBet}`;
+          break;
+        case "raise":
+          msg = `${acted.nickname} bets ${action.amount ?? acted.currentBet}`;
+          break;
+      }
+      get().addLog(msg);
+    },
   };
 });


### PR DESCRIPTION
## Summary
- show generated address in connect button when using demo login
- hide demo login button after session creation
- restrict players to a single seat using stored session id

## Testing
- `yarn format:check` (fails: Code style issues found in 53 files)
- `yarn next:lint` (fails: Failed to load parser './parser.js')
- `yarn next:check-types` (fails: numerous TS errors)
- `yarn test:nextjs` (fails: 3 failed tests)
- `yarn test` (fails: command not found: snforge)


------
https://chatgpt.com/codex/tasks/task_e_68a9c4eb6b308324bfbe95b8a2912b9c