### PR TITLE
feat: support demo user with logout options

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -8,8 +8,6 @@ import DealerWindow from "../../components/DealerWindow";
 import { CustomConnectButton } from "../../components/scaffold-stark/CustomConnectButton";
 import ActionBar from "../../components/ActionBar";
 import { usePlayViewModel } from "../../hooks/usePlayViewModel";
-import { randomAddress } from "../../utils/address";
-import { useAccount } from "@starknet-react/core";
 
 // TODO: display connected address and handle signature (Action Plan 1.3)
 
@@ -24,15 +22,7 @@ export default function PlayPage() {
     handStarted,
     handleActivate,
     socket,
-    sessionId,
   } = usePlayViewModel();
-  const { status } = useAccount();
-
-  function handleDemoPlayer() {
-    const addr = randomAddress();
-    localStorage.setItem("sessionId", addr);
-    window.location.reload();
-  }
 
   return (
     <main
@@ -47,17 +37,9 @@ export default function PlayPage() {
       <header className="relative w-full flex items-center mt-6 mb-4 px-4">
         <AnimatedTitle text="Poker Night on Starknet" />
         <div className="flex flex-1 items-center justify-end">
-          <div className="flex flex-col items-end gap-2">
-            <CustomConnectButton />
-            {status === "disconnected" && !sessionId && (
-              <button
-                className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance border border-gray-500 hover:bg-gradient-nav hover:text-white"
-                onClick={handleDemoPlayer}
-              >
-                Demo Player
-              </button>
-            )}
-          </div>
+            <div className="flex flex-col items-end gap-2">
+              <CustomConnectButton />
+            </div>
           {/* TODO: persist session token and auto-reconnect (Action Plan 1.3) */}
         </div>
       </header>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
@@ -269,10 +269,13 @@ export const AddressInfoDropdown = ({
             <button
               className="menu-item text-secondary-content btn-sm !rounded-xl flex gap-3 py-3"
               type="button"
-              onClick={() => disconnect()}
+              onClick={() => {
+                localStorage.removeItem("sessionId");
+                disconnect();
+              }}
             >
               <ArrowLeftEndOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" />{" "}
-              <span>Disconnect</span>
+              <span>Log out</span>
             </button>
           </li>
         </ul>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -105,6 +105,12 @@ const ConnectModal = () => {
             <div className="flex flex-col gap-4 w-full px-8 py-10">
               {!isBurnerWallet ? (
                 <>
+                  <button
+                    className="py-2 px-4 rounded border border-gray-500 hover:bg-gradient-modal"
+                    onClick={handleDemoPlayer}
+                  >
+                    Demo Player
+                  </button>
                   {connectors.map((connector, index) => (
                     <Wallet
                       key={connector.id || index}
@@ -113,12 +119,6 @@ const ConnectModal = () => {
                       handleConnectWallet={handleConnectWallet}
                     />
                   ))}
-                  <button
-                    className="mt-2 py-2 px-4 rounded border border-gray-500 hover:bg-gradient-modal"
-                    onClick={handleDemoPlayer}
-                  >
-                    Demo Player
-                  </button>
                 </>
               ) : (
                 <div className="flex flex-col pb-[20px] justify-end gap-3">

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/DemoInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/DemoInfoDropdown.tsx
@@ -1,0 +1,78 @@
+import { useRef, useState } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import {
+  ArrowLeftEndOnRectangleIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  DocumentDuplicateIcon,
+} from "@heroicons/react/24/outline";
+import { BlockieAvatar } from "~~/components/scaffold-stark";
+import { useOutsideClick } from "~~/hooks/scaffold-stark";
+
+export const DemoInfoDropdown = ({ address }: { address: string }) => {
+  const [addressCopied, setAddressCopied] = useState(false);
+  const dropdownRef = useRef<HTMLDetailsElement>(null);
+  const closeDropdown = () => dropdownRef.current?.removeAttribute("open");
+
+  useOutsideClick(dropdownRef, closeDropdown);
+
+  const handleLogout = () => {
+    localStorage.removeItem("sessionId");
+    window.location.reload();
+  };
+
+  return (
+    <details ref={dropdownRef} className="dropdown dropdown-end leading-3">
+      <summary className="btn bg-transparent btn-sm px-2 py-[0.35rem] gap-0 !h-auto border border-[#5c4fe5] dropdown-toggle">
+        <BlockieAvatar address={address} size={28} />
+        <span className="ml-2 mr-2 text-sm">
+          {address.slice(0, 6)}...{address.slice(-4)}
+        </span>
+        <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0 sm:block hidden" />
+      </summary>
+      <ul
+        tabIndex={0}
+        className="dropdown-content menu z-[2] p-2 mt-2 rounded-[5px] gap-1 border border-[#5c4fe5] bg-base-100"
+      >
+        <li>
+          {addressCopied ? (
+            <div className="btn-sm !rounded-xl flex gap-3 py-3">
+              <CheckCircleIcon
+                className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
+                aria-hidden="true"
+              />
+              <span className="whitespace-nowrap">Copy address</span>
+            </div>
+          ) : (
+            <CopyToClipboard
+              text={address}
+              onCopy={() => {
+                setAddressCopied(true);
+                setTimeout(() => setAddressCopied(false), 800);
+              }}
+            >
+              <div className="btn-sm !rounded-xl flex gap-3 py-3">
+                <DocumentDuplicateIcon
+                  className="text-xl font-normal h-6 w-4 cursor-pointer ml-2 sm:ml-0"
+                  aria-hidden="true"
+                />
+                <span className="whitespace-nowrap">Copy address</span>
+              </div>
+            </CopyToClipboard>
+          )}
+        </li>
+        <li>
+          <button
+            className="menu-item text-secondary-content btn-sm !rounded-xl flex gap-3 py-3"
+            type="button"
+            onClick={handleLogout}
+          >
+            <ArrowLeftEndOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" />
+            <span>Log out</span>
+          </button>
+        </li>
+      </ul>
+    </details>
+  );
+};
+

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/index.tsx
@@ -5,7 +5,7 @@ import { Balance } from "../Balance";
 import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { WrongNetworkDropdown } from "./WrongNetworkDropdown";
-import { BlockieAvatar } from "../BlockieAvatar";
+import { DemoInfoDropdown } from "./DemoInfoDropdown";
 import { useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-stark";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-stark";
@@ -83,14 +83,7 @@ export const CustomConnectButton = () => {
 
   if (status === "disconnected") {
     if (demoAddress) {
-      return (
-        <div className="btn bg-transparent btn-sm px-2 py-[0.35rem] gap-2 !h-auto border border-[#5c4fe5]">
-          <BlockieAvatar address={demoAddress} size={28} />
-          <span className="text-sm">
-            {demoAddress.slice(0, 6)}...{demoAddress.slice(-4)}
-          </span>
-        </div>
-      );
+      return <DemoInfoDropdown address={demoAddress} />;
     }
     return <ConnectModal />;
   }


### PR DESCRIPTION
## Summary
- add demo player dropdown with copy and logout actions
- move demo player into connect modal
- clear session ID on logout

## Testing
- `yarn next:lint` *(fails: eslint-config-next tried to access next)*
- `yarn next:check-types` *(fails: JSX element implicitly has type 'any')*
- `yarn test:nextjs` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ca36c4b88324a952ad5473fb074e