### PR TITLE
feat: broadcast round events and action prompts

### DIFF
--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -32,6 +32,7 @@ export {
   isRoomRoundComplete,
   payout,
   startRoomHand,
+  progressStage,
 } from "./room";
 export * from "./hashEvaluator";
 export * from "./handEvaluator";


### PR DESCRIPTION
## Summary
- check round completion after actions and advance stage
- broadcast street events and action prompts before table snapshots
- re-export progressStage from backend module

## Testing
- `yarn test:nextjs` *(fails: expected 1 to be +0, expected +0 to be 1, 2 !== 3)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cb21d45883249753590a796aa9f2