### PR TITLE
Refine dealer window and mobile UI

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -14,7 +14,6 @@ import { usePlayViewModel } from "../../hooks/usePlayViewModel";
 export default function PlayPage() {
   const {
     street,
-    dealFlop,
     dealTurn,
     dealRiver,
     timer,
@@ -46,20 +45,19 @@ export default function PlayPage() {
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} socket={socket} />
       </div>
-      <DealerWindow />
       <div
         id="action-buttons"
-        className="fixed bottom-0 right-0 flex justify-end p-4 z-10"
+        className="fixed right-0 flex justify-end p-4 z-10 bottom-10 sm:bottom-0"
       >
         <ActionBar
           street={stageNames[street] ?? "preflop"}
           onActivate={handleActivate}
-          onFlop={dealFlop}
           onTurn={dealTurn}
           onRiver={dealRiver}
           hasHandStarted={handStarted}
         />
       </div>
+      <DealerWindow />
     </main>
   );
 }

--- a/packages/nextjs/components/ActionBar.tsx
+++ b/packages/nextjs/components/ActionBar.tsx
@@ -3,7 +3,6 @@
 interface Props {
   street: string;
   onActivate(): void;
-  onFlop(): void;
   onTurn(): void;
   onRiver(): void;
   hasHandStarted: boolean;
@@ -15,22 +14,13 @@ export default function ActionBar({
   ...actions
 }: Props) {
   return (
-    <div className="flex flex-col gap-2 card p-2 rounded">
+    <div className="flex flex-col gap-2 card p-2 rounded sm:scale-100 scale-[0.85]">
       {street === "preflop" && !hasHandStarted && (
         <button
           onClick={actions.onActivate}
           className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white"
         >
-          Activate
-        </button>
-      )}
-      {street === "preflop" && (
-        <button
-          onClick={actions.onFlop}
-          disabled={!hasHandStarted}
-          className="py-1.5 px-3 text-sm rounded-full font-serif-renaissance hover:bg-gradient-nav hover:text-white disabled:opacity-50"
-        >
-          Deal Flop
+          Start
         </button>
       )}
       {street === "flop" && (

--- a/packages/nextjs/components/DealerWindow.tsx
+++ b/packages/nextjs/components/DealerWindow.tsx
@@ -19,12 +19,10 @@ export default function DealerWindow() {
 
   const displayLogs = isMobile && !expanded ? logs.slice(-1) : logs;
 
-  const base =
-    "fixed left-4 bottom-0 w-64 bg-black/50 text-white rounded text-xs z-10";
+  const base = `fixed left-4 ${isMobile ? "bottom-0" : "bottom-20"} w-64 bg-black/50 text-white rounded text-xs z-10 sm:scale-100 scale-[0.85]`;
 
   const collapsed = "h-5 p-1 overflow-hidden cursor-pointer flex items-center";
-  const open =
-    "max-h-40 p-2 overflow-y-auto flex flex-col justify-end space-y-1";
+  const open = "h-24 p-2 overflow-y-auto flex flex-col justify-end space-y-1";
 
   return (
     <div

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/AddressInfoDropdown.tsx
@@ -267,7 +267,7 @@ export const AddressInfoDropdown = ({
           ) : null} */}
           <li className={selectingNetwork ? "hidden" : ""}>
             <button
-              className="menu-item text-secondary-content btn-sm !rounded-xl flex gap-3 py-3"
+              className="btn-sm !rounded-xl flex gap-3 py-3"
               type="button"
               onClick={() => {
                 localStorage.removeItem("sessionId");
@@ -275,7 +275,7 @@ export const AddressInfoDropdown = ({
               }}
             >
               <ArrowLeftEndOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" />{" "}
-              <span>Log out</span>
+              <span className="whitespace-nowrap">Log out</span>
             </button>
           </li>
         </ul>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -106,10 +106,15 @@ const ConnectModal = () => {
               {!isBurnerWallet ? (
                 <>
                   <button
-                    className="py-2 px-4 rounded border border-gray-500 hover:bg-gradient-modal"
+                    className={`flex gap-4 items-center text-black rounded-[4px] p-3 transition-all border ${
+                      isDarkMode
+                        ? "hover:bg-[#385183] border-[#4f4ab7]"
+                        : "hover:bg-slate-200 border-[#5c4fe5]"
+                    }`}
                     onClick={handleDemoPlayer}
                   >
-                    Demo Player
+                    <div className="h-[1.5rem] w-[1.5rem]" />
+                    <span className="text-start m-0">Demo Player</span>
                   </button>
                   {connectors.map((connector, index) => (
                     <Wallet
@@ -129,9 +134,9 @@ const ConnectModal = () => {
                         className="w-full flex flex-col"
                       >
                         <button
-                        className={`hover:bg-gradient-modal border rounded-md text-black py-[8px] pl-[10px] pr-16 flex items-center gap-4 ${
-                          isDarkMode ? "border-[#385183]" : ""
-                        }`}
+                          className={`hover:bg-gradient-modal border rounded-md text-black py-[8px] pl-[10px] pr-16 flex items-center gap-4 ${
+                            isDarkMode ? "border-[#385183]" : ""
+                          }`}
                           onClick={(e) => handleConnectBurner(e, ix)}
                         >
                           <BlockieAvatar

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/DemoInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/DemoInfoDropdown.tsx
@@ -63,12 +63,12 @@ export const DemoInfoDropdown = ({ address }: { address: string }) => {
         </li>
         <li>
           <button
-            className="menu-item text-secondary-content btn-sm !rounded-xl flex gap-3 py-3"
+            className="btn-sm !rounded-xl flex gap-3 py-3"
             type="button"
             onClick={handleLogout}
           >
             <ArrowLeftEndOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" />
-            <span>Log out</span>
+            <span className="whitespace-nowrap">Log out</span>
           </button>
         </li>
       </ul>

--- a/packages/nextjs/hooks/usePlayViewModel.ts
+++ b/packages/nextjs/hooks/usePlayViewModel.ts
@@ -10,7 +10,6 @@ export function usePlayViewModel() {
   const {
     street,
     startHand,
-    dealFlop,
     dealTurn,
     dealRiver,
     playerHands,
@@ -93,7 +92,6 @@ export function usePlayViewModel() {
 
   return {
     street,
-    dealFlop,
     dealTurn,
     dealRiver,
     timer,

--- a/packages/nextjs/hooks/useTableViewModel.ts
+++ b/packages/nextjs/hooks/useTableViewModel.ts
@@ -83,7 +83,7 @@ export function useTableViewModel(timer?: number | null, socket?: WebSocket | nu
         (window.innerHeight - bottomSpace) / baseH,
         1,
       );
-      setTableScale(scale);
+      setTableScale(isMobile ? scale * 0.85 : scale);
     };
     handle();
     window.addEventListener("resize", handle);


### PR DESCRIPTION
## Summary
- Rename "Activate" action to "Start" and drop unused flop button
- Uniform logout styling, reposition dealer messages, and shrink mobile table
- Style the Demo Player connect option to match wallet buttons

## Testing
- `yarn workspace @ss-2/nextjs lint` *(fails: eslint-config-next tried to access next...)*
- `yarn workspace @ss-2/nextjs test run` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f049b2d88324b0c5094d643a900e