### PR TITLE
feat(server): add user identity model

### DIFF
--- a/packages/nextjs/backend/networking.ts
+++ b/packages/nextjs/backend/networking.ts
@@ -3,7 +3,7 @@ import type { Card, Table, PlayerAction, Round } from "./types";
 export type BlindType = "SMALL" | "BIG";
 
 export type ServerEvent =
-  | { tableId: string; type: "SESSION"; userId: string }
+  | { tableId: string; type: "SESSION"; sessionId: string; userId?: string }
   | { tableId: string; type: "TABLE_SNAPSHOT"; table: Table }
   | { tableId: string; type: "HAND_START" }
   | { tableId: string; type: "BLINDS_POSTED" }
@@ -42,6 +42,7 @@ export type ServerEvent =
   | { tableId: string; type: "ERROR"; code: string; msg: string };
 
 export type ClientCommand =
+  | { cmdId: string; type: "ATTACH"; userId: string }
   | { cmdId: string; type: "SIT"; tableId: string; buyIn: number }
   | { cmdId: string; type: "LEAVE" }
   | { cmdId: string; type: "SIT_OUT" }

--- a/packages/nextjs/server/user.ts
+++ b/packages/nextjs/server/user.ts
@@ -1,0 +1,20 @@
+export type UserId = string;
+
+export interface User {
+  /** Canonical identifier, e.g. wallet address */
+  id: UserId;
+  nickname?: string;
+}
+
+/** Simple in-memory user registry */
+export class InMemoryUserStore {
+  private users = new Map<UserId, User>();
+
+  get(id: UserId): User | undefined {
+    return this.users.get(id);
+  }
+
+  upsert(user: User): void {
+    this.users.set(user.id, user);
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory user model
- track user IDs in session manager
- allow attaching sessions by user ID and carry IDs through server events

## Testing
- ❌ `yarn test:nextjs`
- ⚠️ `yarn next:lint`
- ⚠️ `yarn next:check-types`


------
https://chatgpt.com/codex/tasks/task_e_68aa44ee949083248ed0a6385300e242