### PR TITLE
feat: support session reattachment and graceful disconnects

### DIFF
--- a/packages/nextjs/backend/networking.ts
+++ b/packages/nextjs/backend/networking.ts
@@ -47,6 +47,7 @@ export type ServerEvent =
 
 export type ClientCommand =
   | { cmdId: string; type: "ATTACH"; userId: string }
+  | { cmdId: string; type: "REATTACH"; sessionId: string }
   | { cmdId: string; type: "SIT"; tableId: string; buyIn: number }
   | { cmdId: string; type: "LEAVE" }
   | { cmdId: string; type: "SIT_OUT" }


### PR DESCRIPTION
## Summary
- handle disconnects by emitting PLAYER_DISCONNECTED immediately and scheduling seat removal with cancellable timers
- allow sessions to reattach using sessionId and broadcast PLAYER_REJOINED when returning within the grace period
- expose session manager helpers for socket swapping and session expiry

## Testing
- `yarn test:nextjs` *(fails: expected +0 to be 1, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5148485c8324a94d2789c53c71f2