### PR TITLE
feat: switch game store to websocket

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -20,7 +20,6 @@ export default function PlayPage() {
     stageNames,
     handStarted,
     handleActivate,
-    socket,
   } = usePlayViewModel();
 
   return (
@@ -43,7 +42,7 @@ export default function PlayPage() {
         </div>
       </header>
       <div className="flex-1 flex items-center justify-center">
-        <Table timer={timer} socket={socket} />
+        <Table timer={timer} />
       </div>
       <div
         id="action-buttons"

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -12,10 +12,8 @@ import type { UiPlayer, Card as TCard } from "../backend";
 
 export default function Table({
   timer,
-  socket,
 }: {
   timer?: number | null;
-  socket?: WebSocket | null;
 }) {
   const {
     players,
@@ -41,7 +39,7 @@ export default function Table({
     displayTimer,
     actionDisabled,
     handleActionClick,
-  } = useTableViewModel(timer, socket);
+  } = useTableViewModel(timer);
 
   const holeCardSize = "sm";
 

--- a/packages/nextjs/hooks/useTableViewModel.ts
+++ b/packages/nextjs/hooks/useTableViewModel.ts
@@ -45,7 +45,7 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
   });
 };
 
-export function useTableViewModel(timer?: number | null, socket?: WebSocket | null) {
+export function useTableViewModel(timer?: number | null) {
   const {
     players,
     playerHands,
@@ -152,17 +152,6 @@ export function useTableViewModel(timer?: number | null, socket?: WebSocket | nu
   const displayTimer = actionTimer ?? timer ?? 0;
 
   const handleActionClick = (action: string) => {
-    // emit PlayerAction messages via networking contract when socket is available
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload: any = {
-        cmdId: crypto.randomUUID(),
-        type: "ACTION",
-        action: action.toUpperCase(),
-        amount: action === "Bet" || action === "Raise" ? bet : undefined,
-        tableId: "demo",
-      };
-      socket.send(JSON.stringify(payload));
-    }
     switch (action) {
       case "Fold":
         playerAction({ type: "fold" });


### PR DESCRIPTION
## Summary
- replace in-memory GameEngine with WebSocket client and ATTACH handshake
- sync server events to Zustand store and expose actions sending ClientCommands
- simplify view model components to rely on shared WebSocket state

## Testing
- `yarn test:nextjs` *(fails: room helpers > handles hand flow and payouts, Dealer & BettingEngine > enforces min-raise and round completion)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5402e7e883248921a26a96c041fd