### PR TITLE
feat: wallet auto-attach and seat reconnect

### DIFF
--- a/packages/nextjs/backend/types.ts
+++ b/packages/nextjs/backend/types.ts
@@ -66,6 +66,8 @@ export interface GameRoom {
 
 export interface UiPlayer {
   name: string;
+  /** full wallet address */
+  address?: string;
   chips: number;
   hand: [Card, Card] | null;
   folded: boolean;

--- a/packages/nextjs/components/PlayerSeat.tsx
+++ b/packages/nextjs/components/PlayerSeat.tsx
@@ -67,15 +67,20 @@ export default function PlayerSeat({
 
       <div
         className={clsx(
-          "absolute inset-0 flex items-center justify-center rounded border font-semibold text-center truncate px-1 transition-colors",
+          "absolute inset-0 flex flex-col items-center justify-center rounded border font-semibold text-center px-1 transition-colors",
           isActive
             ? "bg-[var(--color-accent)] border-[var(--color-accent)]"
             : "bg-black/60 border-gray-500 hover:bg-red-500 hover:border-red-500",
         )}
       >
-        <span className="text-[var(--color-highlight)]">
-          {shortAddress(player.name)}
+        <span className="text-[var(--color-highlight)] truncate w-full">
+          {player.name}
         </span>
+        {player.address && (
+          <span className="text-xs w-full truncate">
+            {shortAddress(player.address)}
+          </span>
+        )}
       </div>
       {state === PlayerState.ALL_IN && (
         <span className="absolute -bottom-5 left-1/2 -translate-x-1/2 text-xs text-yellow-300 font-bold">

--- a/packages/nextjs/hooks/useTableViewModel.ts
+++ b/packages/nextjs/hooks/useTableViewModel.ts
@@ -48,6 +48,7 @@ const buildLayout = (isMobile: boolean): SeatPos[] => {
 export function useTableViewModel(timer?: number | null) {
   const {
     players,
+    playerIds,
     playerHands,
     community,
     joinSeat,
@@ -174,6 +175,7 @@ export function useTableViewModel(timer?: number | null) {
 
   return {
     players,
+    playerIds,
     playerHands,
     community,
     joinSeat,


### PR DESCRIPTION
## Summary
- prompt users to connect wallet before entering table and persist address locally
- auto-attach sockets with stored wallet and auto-sit when reconnecting
- show short wallet addresses next to player nicknames

## Testing
- `yarn test:nextjs` *(fails: AssertionError and ERR_INVALID_ARG_TYPE)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37d4897483248f26f7388729552e