### PR TITLE
feat: lobby table registry and websocket commands

### DIFF
--- a/packages/nextjs/app/lobby/page.test.tsx
+++ b/packages/nextjs/app/lobby/page.test.tsx
@@ -1,13 +1,31 @@
-import { render, screen } from '@testing-library/react';
-import LobbyPage from './page';
-import { expect, test } from 'vitest';
+import { render, screen } from "@testing-library/react";
+import LobbyPage from "./page";
+import { expect, test } from "vitest";
 
-// basic render test for lobby
+class MockWebSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  constructor() {
+    setTimeout(() => this.onopen && this.onopen(), 0);
+  }
+  send() {
+    const payload = {
+      tableId: "",
+      type: "TABLE_LIST",
+      tables: [{ id: "demo", name: "Demo" }],
+    };
+    setTimeout(() => this.onmessage && this.onmessage({ data: JSON.stringify(payload) }), 0);
+  }
+  close() {}
+}
 
-test('renders lobby with table links', () => {
+// @ts-ignore
+global.WebSocket = MockWebSocket;
+
+test("renders lobby with table links", async () => {
   render(<LobbyPage />);
-  expect(screen.getByText('Lobby')).toBeInTheDocument();
-  const links = screen.getAllByRole('link', { name: 'Join' });
-  expect(links[0]).toHaveAttribute('href', '/play?table=demo');
+  expect(screen.getByText("Lobby")).toBeInTheDocument();
+  const link = await screen.findByRole("link", { name: "Join" });
+  expect(link).toHaveAttribute("href", "/play?table=demo");
 });
 

--- a/packages/nextjs/app/lobby/page.tsx
+++ b/packages/nextjs/app/lobby/page.tsx
@@ -1,28 +1,44 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-
-interface TableInfo {
-  id: string;
-  name: string;
-  stakes: string;
-}
-
-const TABLES: TableInfo[] = [
-  { id: 'demo', name: 'Demo Table', stakes: 'Free' },
-  { id: 'high', name: 'High Stakes', stakes: '50/100' },
-];
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { LobbyTable } from "../../backend";
 
 export default function LobbyPage() {
+  const [tables, setTables] = useState<LobbyTable[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.WebSocket) return;
+    const ws = new WebSocket("ws://localhost:8080");
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({ cmdId: Date.now().toString(), type: "LIST_TABLES" })
+      );
+    };
+    ws.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(e.data);
+        if (msg.type === "TABLE_LIST") {
+          setTables(msg.tables);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    return () => ws.close();
+  }, []);
+
   return (
     <main className="p-6 text-white">
       <h1 className="text-2xl mb-4">Lobby</h1>
       <ul className="space-y-3">
-        {TABLES.map((t) => (
-          <li key={t.id} className="flex items-center justify-between bg-black/40 rounded p-4">
+        {tables.map((t) => (
+          <li
+            key={t.id}
+            className="flex items-center justify-between bg-black/40 rounded p-4"
+          >
             <div>
               <div className="font-semibold">{t.name}</div>
-              <div className="text-sm text-gray-300">Stakes: {t.stakes}</div>
             </div>
             <Link
               href={`/play?table=${t.id}`}

--- a/packages/nextjs/backend/index.ts
+++ b/packages/nextjs/backend/index.ts
@@ -21,7 +21,7 @@ export type {
   HandAction,
   HandLog,
 } from "./types";
-export type { ServerEvent, ClientCommand } from "./networking";
+export type { ServerEvent, ClientCommand, LobbyTable } from "./networking";
 export * from "./utils";
 export {
   createRoom,

--- a/packages/nextjs/backend/networking.ts
+++ b/packages/nextjs/backend/networking.ts
@@ -1,10 +1,17 @@
 import type { Card, Table, PlayerAction, Round } from "./types";
 
+export interface LobbyTable {
+  id: string;
+  name: string;
+}
+
 export type BlindType = "SMALL" | "BIG";
 
 export type ServerEvent =
   | { tableId: string; type: "SESSION"; sessionId: string; userId?: string }
   | { tableId: string; type: "TABLE_SNAPSHOT"; table: Table }
+  | { tableId: ""; type: "TABLE_LIST"; tables: LobbyTable[] }
+  | { tableId: string; type: "TABLE_CREATED"; table: LobbyTable }
   | { tableId: string; type: "HAND_START" }
   | { tableId: string; type: "BLINDS_POSTED" }
   | { tableId: string; type: "DEAL_HOLE"; seat: number; cards: [Card, Card] }
@@ -48,6 +55,8 @@ export type ServerEvent =
 export type ClientCommand =
   | { cmdId: string; type: "ATTACH"; userId: string }
   | { cmdId: string; type: "REATTACH"; sessionId: string }
+  | { cmdId: string; type: "LIST_TABLES" }
+  | { cmdId: string; type: "CREATE_TABLE"; name: string }
   | { cmdId: string; type: "SIT"; tableId: string; buyIn: number }
   | { cmdId: string; type: "LEAVE" }
   | { cmdId: string; type: "SIT_OUT" }

--- a/packages/nextjs/server/lobby.ts
+++ b/packages/nextjs/server/lobby.ts
@@ -1,0 +1,20 @@
+import { GameEngine } from "../backend";
+import type { LobbyTable } from "../backend";
+
+interface RegistryEntry extends LobbyTable {
+  engine: GameEngine;
+}
+
+const registry = new Map<string, RegistryEntry>();
+
+export function listTables(): LobbyTable[] {
+  return Array.from(registry.values()).map(({ id, name }) => ({ id, name }));
+}
+
+export function getEngine(id: string): GameEngine | undefined {
+  return registry.get(id)?.engine;
+}
+
+export function registerTable(id: string, engine: GameEngine, name?: string) {
+  registry.set(id, { id, name: name ?? id, engine });
+}


### PR DESCRIPTION
## Summary
- add server-side lobby registry for game tables
- support LIST_TABLES and CREATE_TABLE websocket commands
- stub lobby page to fetch tables over websocket

## Testing
- `yarn next:lint` *(fails: Failed to load parser './parser.js' declared in '.eslintrc.json » eslint-config-next': eslint-config-next tried to access next, but it isn't declared in its dependencies)*
- `yarn workspace @ss-2/nextjs test app/lobby/page.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab3a4f59f883248d98ff710dcaed14