### PR TITLE
Use header connect button and remove duplicate

### DIFF
--- a/packages/nextjs/app/play/page.tsx
+++ b/packages/nextjs/app/play/page.tsx
@@ -5,7 +5,6 @@
 import Table from "../../components/Table";
 import AnimatedTitle from "../../components/AnimatedTitle";
 import DealerWindow from "../../components/DealerWindow";
-import { CustomConnectButton } from "../../components/scaffold-stark/CustomConnectButton";
 import ActionBar from "../../components/ActionBar";
 import { usePlayViewModel } from "../../hooks/usePlayViewModel";
 
@@ -32,14 +31,8 @@ export default function PlayPage() {
         backgroundRepeat: "no-repeat",
       }}
     >
-      <header className="relative w-full flex items-center mt-6 mb-4 px-4">
+      <header className="relative w-full flex items-center justify-center mt-6 mb-4 px-4">
         <AnimatedTitle text="Poker Night on Starknet" />
-        <div className="flex flex-1 items-center justify-end">
-            <div className="flex flex-col items-end gap-2">
-              <CustomConnectButton />
-            </div>
-          {/* TODO: persist session token and auto-reconnect (Action Plan 1.3) */}
-        </div>
       </header>
       <div className="flex-1 flex items-center justify-center">
         <Table timer={timer} />

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -145,6 +145,9 @@ export const Header = () => {
           <HeaderMenuLinks />
         </ul>
       </div>
+      <div className="navbar-end flex-1 justify-end pr-4">
+        <CustomConnectButton />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show wallet connect button in site header
- remove redundant connect button from Play page

## Testing
- `npx prettier packages/nextjs/components/Header.tsx packages/nextjs/app/play/page.tsx --write`
- `yarn next:lint` *(fails: @typescript-eslint/parser missing)*
- `yarn test:nextjs` *(watch mode cancelled after tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9e994620832496bbb84b3f5177c1