### PR TITLE
Require wallet before seating and propagate wallet ID

### DIFF
--- a/packages/nextjs/backend/networking.ts
+++ b/packages/nextjs/backend/networking.ts
@@ -62,7 +62,13 @@ export type ClientCommand =
   | { cmdId: string; type: "REATTACH"; sessionId: string }
   | { cmdId: string; type: "LIST_TABLES" }
   | { cmdId: string; type: "CREATE_TABLE"; name: string }
-  | { cmdId: string; type: "SIT"; tableId: string; buyIn: number }
+  | {
+      cmdId: string;
+      type: "SIT";
+      tableId: string;
+      buyIn: number;
+      userId?: string;
+    }
   | { cmdId: string; type: "LEAVE" }
   | { cmdId: string; type: "SIT_OUT" }
   | { cmdId: string; type: "SIT_IN" }

--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -47,6 +47,19 @@ export default function Table({ timer }: { timer?: number | null }) {
     }
   }, [address]);
 
+  const handleSeatRequest = (idx: number) => {
+    const session =
+      typeof window !== "undefined" ? localStorage.getItem("sessionId") : null;
+    if (!session) {
+      const modal = document.getElementById("connect-modal") as
+        | HTMLInputElement
+        | null;
+      if (modal) modal.checked = true;
+      return;
+    }
+    joinSeat(idx);
+  };
+
   // The table is always visible; wallet connections are handled elsewhere.
 
   const holeCardSize = "sm";
@@ -85,7 +98,7 @@ export default function Table({ timer }: { timer?: number | null }) {
           <div>
             {badge}
             <button
-              onClick={() => joinSeat(idx)}
+              onClick={() => handleSeatRequest(idx)}
               className="w-24 h-8 flex items-center justify-center rounded text-xs text-gray-300 border border-dashed border-gray-500 bg-black/20 transition-colors duration-150 hover:bg-red-500 hover:text-white"
             >
               Play

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -101,6 +101,9 @@ const ConnectModal = () => {
               ✕
             </label>
           </div>
+          {!isBurnerWallet && (
+            <p className="mt-2 text-sm">Please login with one of the wallets.</p>
+          )}
           <div className="flex flex-col flex-1 lg:grid">
             <div className="flex flex-col gap-4 w-full px-8 py-10">
               {!isBurnerWallet ? (
@@ -113,7 +116,7 @@ const ConnectModal = () => {
                     }`}
                     onClick={handleDemoPlayer}
                   >
-                    <div className="h-[1.5rem] w-[1.5rem]" />
+                    <div className="h-[1.5rem] w-[1.5rem] rounded-full bg-orange-500" />
                     <span className="text-start m-0">Demo Player</span>
                   </button>
                   {connectors.map((connector, index) => (

--- a/packages/nextjs/hooks/useGameStore.ts
+++ b/packages/nextjs/hooks/useGameStore.ts
@@ -308,6 +308,7 @@ export const useGameStore = create<GameStoreState>((set, get) => {
           type: "SIT",
           tableId: TABLE_ID,
           buyIn: 10000,
+          userId: get().walletId ?? undefined,
         } as any;
         socket.send(JSON.stringify(cmd));
       }


### PR DESCRIPTION
## Summary
- show a login reminder in connect dialog and add orange demo icon
- block seat action without session and prompt to connect
- include wallet ID when sending SIT command

## Testing
- `yarn next:lint` *(fails: Failed to load parser '@typescript-eslint/parser')*
- `yarn test:nextjs` *(fails: TypeError [ERR_INVALID_ARG_TYPE]: The "list[1]" argument must be an instance of Buffer or Uint8Array)*

------
https://chatgpt.com/codex/tasks/task_e_68abe3496d488324ac796975e31f1d3c