### PR TITLE
Improve multiplayer session management documentation and fix disconnect handling

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,3 +23,4 @@ tie back to features discussed across the documents in this directory. See
 - Refactor frontend store to consume WebSocket events instead of a local engine.
 - Add integration tests covering connect → seat → action → disconnect → reconnect.
 - (Optional) Persist sessions and tables in Redis to survive server restarts.
+- Fix failing tests, lint, and type checks to keep baseline green.

--- a/docs/multi-player-server.md
+++ b/docs/multi-player-server.md
@@ -6,6 +6,7 @@ For message formats and command shapes, see [`networking-contract.md`](./network
 ## Session Lifecycle
 
 - When a client connects, the server issues a random **`sessionId`** and stores the WebSocket in `SessionManager`.
+- The server immediately responds with a `SESSION` message so the client learns its connection identifier.
 - A session becomes associated with a persistent user only after the client sends an `ATTACH` command containing its wallet address.
 - The same session record holds both the temporary `sessionId` and the attached `userId`.
 - Disconnects trigger a grace timer via `handleDisconnect`. Reconnecting with the same `userId` before expiry cancels the timer and restores the session.
@@ -21,8 +22,9 @@ For message formats and command shapes, see [`networking-contract.md`](./network
 - One active WebSocket session per wallet address.
 - `ServerEvent` messages include both `sessionId` and `userId` so clients can reconcile their identity after reattaching.
 - Reconnecting within the grace window preserves table membership; expired sessions are removed from room state.
+- Room snapshots are keyed by `userId` so reconnecting clients regain their seat and chip stack.
 
 ## Current Implementation Status
 
-- Wallet-based session attachment and reconnection timers are implemented.
+- Wallet-based session attachment and reconnection timers are implemented, and server events/snapshots reference user IDs.
 - Table state is still managed via simple room helpers; integration with `GameEngine` and richer lifecycle events remain TODO.

--- a/packages/nextjs/server/sessionManager.ts
+++ b/packages/nextjs/server/sessionManager.ts
@@ -59,14 +59,12 @@ export class SessionManager {
 
   handleDisconnect(session: Session, onDisconnect: (session: Session) => void) {
     this.clearTimer(session);
-    session.timeout = setTimeout(() => {
-      this.sessions.delete(session.socket);
-      this.bySessionId.delete(session.sessionId);
-      if (session.userId) {
-        this.byUserId.delete(session.userId);
-      }
-      onExpire(session);
-    }, this.disconnectGraceMs);
+    onDisconnect(session);
+    if (!session.timeout) {
+      session.timeout = setTimeout(() => {
+        this.expire(session);
+      }, this.disconnectGraceMs);
+    }
   }
 
   handleReconnect(session: Session) {


### PR DESCRIPTION
## Summary
- fix SessionManager.handleDisconnect to invoke callback immediately and schedule cleanup only if needed
- document session handshake and snapshot identifiers in multiplayer server guide
- track fixing tests/lint/type checks in TODO

## Testing
- `yarn next:lint`
- `yarn next:check-types` *(fails: missing modules and JSX intrinsic types)*
- `yarn workspace @ss-2/nextjs test --run` *(fails: Node ERR_INVALID_ARG_TYPE after tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abf8cea6088324a0c0d4f454bddf4f