### PR TITLE
Allow seat joining after wallet connection

### DIFF
--- a/packages/nextjs/components/Table.tsx
+++ b/packages/nextjs/components/Table.tsx
@@ -48,9 +48,11 @@ export default function Table({ timer }: { timer?: number | null }) {
   }, [address]);
 
   const handleSeatRequest = (idx: number) => {
-    const session =
-      typeof window !== "undefined" ? localStorage.getItem("sessionId") : null;
-    if (!session) {
+    const wallet =
+      typeof window !== "undefined"
+        ? localStorage.getItem("walletAddress")
+        : null;
+    if (!wallet) {
       const modal = document.getElementById(
         "connect-modal",
       ) as HTMLInputElement | null;


### PR DESCRIPTION
## Summary
- ensure players can sit at the table only when a wallet is connected

## Testing
- `yarn next:lint`
- `yarn next:check-types` *(fails: "JSX element implicitly has type 'any'")*
- `yarn test:nextjs`


------
https://chatgpt.com/codex/tasks/task_e_68ac544631c883249aa61a98ce8b146b